### PR TITLE
[LEGAL-C1] 要配慮個人情報の明示的同意

### DIFF
--- a/documents/REMAINING_TASKS.md
+++ b/documents/REMAINING_TASKS.md
@@ -20,6 +20,13 @@
 | ✅ | OAS-DOC-T02 | ユーザーマニュアル v2 | P1 |
 | ✅ | OAS-DOC-T03 | スクリーンショットスクリプト SPA対応 | P2 |
 | ✅ | OAS-PW-T01 | PasswordInput コンポーネント（表示/非表示トグル） | P2 |
+| ✅ | LEGAL-C1 | 要配慮個人情報の明示的同意（APPI 第20条第2項） | P0 |
+| ⬜ | LEGAL-C2 | 管理者利用規約＆PP同意モーダル | P1 |
+| ⬜ | LEGAL-H1 | データ保存期間ポリシー設定 | P2 |
+| ⬜ | LEGAL-H2 | リマインダーメール配信同意 | P2 |
+| ⬜ | LEGAL-H3 | 患者権利行使機能（開示・訂正・利用停止） | P2 |
+| ⬜ | LEGAL-M1 | 利用規約タブ（Settings画面） | P3 |
+| ⬜ | LEGAL-M2 | PPデフォルトテンプレート | P3 |
 
 ## Security (SEC) — Remaining
 

--- a/documents/WORKLOG.md
+++ b/documents/WORKLOG.md
@@ -11,6 +11,36 @@
 
 ---
 
+## 2026-03-24 Work Log
+
+### Completed Tasks
+
+#### [LEGAL-C1] Sensitive Personal Data Explicit Consent (APPI Article 20(2))
+
+- **Legal basis**: 個人情報保護法 第20条第2項 — explicit consent required before collecting sensitive personal data (health information)
+- **Implementation**: Full-stack consent flow for the "symptoms" field in the reservation form
+  - **PatientForm.tsx**: Consent block with configurable text + checkbox before symptoms textarea; symptoms field disabled until consent given; validation enforces consent
+  - **CF createReservation**: Server-side `hasSensitiveDataConsent === true` validation; rejects API requests without consent flag (prevents bypass)
+  - **Firestore Rules**: `isValidReservation` extended with `hasSensitiveDataConsent` boolean type check
+  - **Evidence storage**: Consent flag persisted in reservation documents for compliance audit trail
+  - **Settings.tsx**: Admin UI textarea for customizing consent text (500 char limit, falls back to default APPI-compliant text)
+- **Types updated**: `ClinicSettings.sensitiveDataConsentText`, `ReservationFormData.hasSensitiveDataConsent`, `ReservationRecord.hasSensitiveDataConsent`
+- **Textarea.tsx**: Added disabled state styling (opacity, bg, cursor)
+- **Code review**: Passed (5-agent review, no issues above 80 confidence threshold)
+- **PR**: #3
+
+#### OAS Emulator Seed Script + Dual-Project Slash Commands
+
+- **seed.js**: New OAS emulator test data script (`functions/seed.js`)
+  - 2 admin users (admin@oas-test.local / staff@oas-test.local) with Auth + custom claims + Firestore profiles
+  - 6 sample reservations (today 3, tomorrow 2, day after 1 cancelled) with slots
+  - Full clinic settings + audit log sample
+  - All reservations include `hasSensitiveDataConsent: true` for C1 compatibility
+- **`/emu-reset` command**: Updated to support `oas` argument (directory, seed script, Vite port auto-detection)
+- **`/emu-stop` command**: Updated to support `oas` / `all` arguments for multi-project port management
+
+---
+
 ## 2026-03-12 Work Log (2)
 
 ### Completed Tasks

--- a/firestore.rules
+++ b/firestore.rules
@@ -31,7 +31,9 @@ service cloud.firestore {
         && (!data.keys().hasAny(['insurance'])     || (data.insurance is string && data.insurance.size() <= 50))
         && (!data.keys().hasAny(['gender'])        || (data.gender is string && data.gender.size() <= 20))
         && (!data.keys().hasAny(['birthdate'])     || (data.birthdate is string && data.birthdate.size() <= 10))
-        && (!data.keys().hasAny(['contactMethod']) || (data.contactMethod is string && data.contactMethod.size() <= 50));
+        && (!data.keys().hasAny(['contactMethod']) || (data.contactMethod is string && data.contactMethod.size() <= 50))
+        // [C1] 要配慮個人情報の同意フラグ（個人情報保護法 第20条第2項）
+        && (!data.keys().hasAny(['hasSensitiveDataConsent']) || (data.hasSensitiveDataConsent is bool));
     }
 
     // [SEC-18] create は Cloud Function (createReservation) 経由のみ

--- a/functions/index.js
+++ b/functions/index.js
@@ -145,6 +145,13 @@ exports.createReservation = onRequest(
       return;
     }
 
+    // ── [C1] 要配慮個人情報の同意検証（個人情報保護法 第20条第2項） ──
+    // 症状フィールドが含まれる場合、明示的な同意フラグが必須
+    if (d.hasSensitiveDataConsent !== true) {
+      res.status(400).json({ error: "健康情報の取り扱いへの同意が必要です" });
+      return;
+    }
+
     // ── 型・長さバリデーション（Firestore Rules の isValidReservation と同等）──
     const checks = [
       [typeof d.name     === "string" && d.name.length     <= 50,  "name"],
@@ -218,6 +225,7 @@ exports.createReservation = onRequest(
           symptoms:      d.symptoms || "",
           notes:         d.notes || "",
           contactMethod: d.contactMethod || "",
+          hasSensitiveDataConsent: true,  // [C1] 同意証跡（サーバー検証済み）
           status:        "pending",
           createdAt:     new Date().toISOString(),
         });

--- a/functions/seed.js
+++ b/functions/seed.js
@@ -1,0 +1,262 @@
+/**
+ * seed.js — OAS エミュレーター用テストデータ作成
+ *
+ * 使い方: node functions/seed.js
+ * 前提: firebase emulators:start 起動済み
+ *
+ * 作成されるデータ:
+ *   - settings/clinic（クリニック基本設定 + 営業時間 + PP）
+ *   - 管理者ユーザー2名（Auth + Firestore + admin カスタムクレーム）
+ *   - サンプル予約6件 + 対応スロット（今日〜2日後）
+ *   - 監査ログサンプル1件
+ *
+ * ログイン情報:
+ *   [管理者]   admin@oas-test.local / Admin001!（パスワード変更不要）
+ *   [スタッフ] staff@oas-test.local / Staff001!（初回パスワード変更必要）
+ */
+
+process.env.FIREBASE_AUTH_EMULATOR_HOST = "localhost:9099";
+process.env.FIRESTORE_EMULATOR_HOST     = "localhost:8080";
+
+const admin  = require("firebase-admin");
+const crypto = require("crypto");
+
+admin.initializeApp({
+  projectId:  "project-3040e21e-879f-4c66-a7d",
+  credential: admin.credential.applicationDefault(),
+});
+
+const db   = admin.firestore();
+const auth = admin.auth();
+
+// ── クリニック設定 ────────────────────────────────────────────────
+const CLINIC_SETTINGS = {
+  clinicName:      "テストクリニック",
+  phone:           "03-1234-5678",
+  clinicUrl:       "https://example.com",
+  clinicZip:       "100-0001",
+  clinicAddress:   "東京都千代田区千代田1-1",
+  clinicAddressSub: "テストビル2F",
+  clinicLogo:      "",
+  businessHours: {
+    "0": { open: false, amOpen: false, amStart: "9:00", amEnd: "12:00", pmOpen: false, pmStart: "14:00", pmEnd: "18:00" },
+    "1": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: true,  pmStart: "14:00", pmEnd: "18:00" },
+    "2": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: true,  pmStart: "14:00", pmEnd: "18:00" },
+    "3": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: false, pmStart: "14:00", pmEnd: "18:00" },
+    "4": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: true,  pmStart: "14:00", pmEnd: "18:00" },
+    "5": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: true,  pmStart: "14:00", pmEnd: "18:00" },
+    "6": { open: true,  amOpen: true,  amStart: "9:00", amEnd: "12:00", pmOpen: false, pmStart: "14:00", pmEnd: "18:00" },
+  },
+  holidays:     [],
+  holidayNames: {},
+  bookingCutoffMinutes: 60,
+  cancelCutoffMinutes:  120,
+  announcement: { active: false, type: "info", message: "", startDate: null, endDate: null },
+  maintenance:  { startDate: null, endDate: null },
+  privacyPolicy: [
+    "当院は、患者様の個人情報を適切に管理し、以下の目的にのみ使用いたします。",
+    "",
+    "1. 診療および治療に関する業務",
+    "2. 予約管理および確認連絡",
+    "3. 医療保険事務",
+    "4. 当院内部での医療サービス向上のための分析",
+    "",
+    "個人情報の第三者への提供は、法令に基づく場合を除き、患者様の同意なく行いません。",
+    "",
+    "個人情報に関するお問い合わせは、受付窓口までお願いいたします。",
+  ].join("\n"),
+  sensitiveDataConsentText: '',  // 空 = デフォルト文言使用
+  updatedAt: new Date().toISOString(),
+};
+
+// ── 管理者ユーザー ────────────────────────────────────────────────
+const ADMIN_USERS = [
+  {
+    email:       "admin@oas-test.local",
+    password:    "Admin001!",
+    displayName: "管理者テスト",
+    mustChangePassword: false,  // テスト用 — すぐログイン可能
+  },
+  {
+    email:       "staff@oas-test.local",
+    password:    "Staff001!",
+    displayName: "スタッフテスト",
+    mustChangePassword: true,   // 初回パスワード変更フロー確認用
+  },
+];
+
+// ── サンプル予約 ──────────────────────────────────────────────────
+function dateStr(daysFromToday) {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  return d.toISOString().split("T")[0];
+}
+
+const SAMPLE_RESERVATIONS = [
+  // 今日 — 午前2件 + 午後1件
+  {
+    date: dateStr(0), time: "9:00",
+    name: "山田太郎", furigana: "ヤマダタロウ", birthdate: "1985-04-15",
+    zip: "100-0001", address: "東京都千代田区千代田1-2-3",
+    phone: "090-1234-5678", email: "yamada@example.com",
+    gender: "男性", visitType: "初診", insurance: "社保",
+    symptoms: "頭痛が3日間続いています", notes: "", contactMethod: "電話",
+    status: "confirmed",
+    hasSensitiveDataConsent: true,
+  },
+  {
+    date: dateStr(0), time: "10:00",
+    name: "佐藤花子", furigana: "サトウハナコ", birthdate: "1990-08-22",
+    zip: "150-0001", address: "東京都渋谷区神宮前2-3-4",
+    phone: "080-2345-6789", email: "sato@example.com",
+    gender: "女性", visitType: "再診", insurance: "国保",
+    symptoms: "定期検診", notes: "前回の血液検査結果確認", contactMethod: "メール",
+    status: "confirmed",
+    hasSensitiveDataConsent: true,
+  },
+  {
+    date: dateStr(0), time: "14:00",
+    name: "鈴木一郎", furigana: "スズキイチロウ", birthdate: "1975-12-01",
+    zip: "160-0001", address: "東京都新宿区片町1-2",
+    phone: "070-3456-7890", email: "",
+    gender: "男性", visitType: "初診", insurance: "社保",
+    symptoms: "腰の痛みが1週間ほど続いている", notes: "", contactMethod: "電話",
+    status: "pending",
+    hasSensitiveDataConsent: true,
+  },
+  // 明日 — 2件
+  {
+    date: dateStr(1), time: "9:30",
+    name: "田中美咲", furigana: "タナカミサキ", birthdate: "2000-03-10",
+    zip: "110-0001", address: "東京都台東区谷中3-4-5",
+    phone: "090-4567-8901", email: "tanaka@example.com",
+    gender: "女性", visitType: "初診", insurance: "社保",
+    symptoms: "咳が続いている", notes: "", contactMethod: "メール",
+    status: "pending",
+    hasSensitiveDataConsent: true,
+  },
+  {
+    date: dateStr(1), time: "15:00",
+    name: "高橋健太", furigana: "タカハシケンタ", birthdate: "1968-07-20",
+    zip: "170-0001", address: "東京都豊島区西巣鴨4-5-6",
+    phone: "080-5678-9012", email: "takahashi@example.com",
+    gender: "男性", visitType: "再診", insurance: "国保",
+    symptoms: "血圧の経過観察", notes: "降圧剤服用中", contactMethod: "電話",
+    status: "pending",
+    hasSensitiveDataConsent: true,
+  },
+  // 明後日 — キャンセル済み1件
+  {
+    date: dateStr(2), time: "11:00",
+    name: "渡辺由美", furigana: "ワタナベユミ", birthdate: "1995-11-30",
+    zip: "180-0001", address: "東京都武蔵野市吉祥寺1-2-3",
+    phone: "090-6789-0123", email: "watanabe@example.com",
+    gender: "女性", visitType: "初診", insurance: "社保",
+    symptoms: "皮膚のかゆみ", notes: "", contactMethod: "メール",
+    status: "cancelled",
+    hasSensitiveDataConsent: true,
+  },
+];
+
+// ── メイン ────────────────────────────────────────────────────────
+async function main() {
+  console.log("=== OAS シードデータ投入開始 ===\n");
+
+  // 1. クリニック設定
+  console.log("[1/4] settings/clinic を作成...");
+  await db.collection("settings").doc("clinic").set(CLINIC_SETTINGS);
+  console.log("  ✓ クリニック設定作成完了");
+
+  // 2. 管理者ユーザー（Auth + Firestore + カスタムクレーム）
+  console.log("[2/4] 管理者ユーザーを作成...");
+  for (const u of ADMIN_USERS) {
+    try {
+      const rec = await auth.createUser({
+        email:       u.email,
+        password:    u.password,
+        displayName: u.displayName,
+      });
+      await auth.setCustomUserClaims(rec.uid, { admin: true });
+      await db.collection("users").doc(rec.uid).set({
+        uid:                 rec.uid,
+        email:               u.email,
+        displayName:         u.displayName,
+        isAdmin:             true,
+        mustChangePassword:  u.mustChangePassword,
+        createdAt:           new Date().toISOString(),
+      });
+      console.log(`  ✓ ${u.email} (UID: ${rec.uid}) — mustChangePassword: ${u.mustChangePassword}`);
+    } catch (err) {
+      if (err.code === "auth/email-already-exists") {
+        console.log(`  ⚠ ${u.email} は既に存在（スキップ）`);
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  // 3. サンプル予約 + スロット
+  console.log("[3/4] サンプル予約・スロットを作成...");
+  for (const r of SAMPLE_RESERVATIONS) {
+    const id     = crypto.randomUUID();
+    const slotId = `${r.date}_${r.time.replace(":", "")}`;
+
+    await db.collection("slots").doc(slotId).set({
+      date:          r.date,
+      time:          r.time,
+      reservationId: id,
+      status:        r.status === "cancelled" ? "cancelled" : "pending",
+    });
+
+    await db.collection("reservations").doc(id).set({
+      id,
+      date:          r.date,
+      time:          r.time,
+      name:          r.name,
+      furigana:      r.furigana,
+      birthdate:     r.birthdate,
+      zip:           r.zip,
+      address:       r.address,
+      phone:         r.phone,
+      email:         r.email,
+      gender:        r.gender,
+      visitType:     r.visitType,
+      insurance:     r.insurance,
+      symptoms:      r.symptoms,
+      notes:         r.notes,
+      contactMethod: r.contactMethod,
+      hasSensitiveDataConsent: r.hasSensitiveDataConsent ?? false,
+      status:        r.status,
+      createdAt:     new Date().toISOString(),
+    });
+
+    console.log(`  ✓ ${r.date} ${r.time} — ${r.name}（${r.status}）`);
+  }
+
+  // 4. 監査ログサンプル
+  console.log("[4/4] 監査ログサンプルを作成...");
+  await db.collection("audit_logs").add({
+    action:      "seed_executed",
+    performedBy: "system",
+    timestamp:   new Date().toISOString(),
+    details:     "テストデータ投入（OAS シードスクリプト）",
+  });
+  console.log("  ✓ 監査ログ作成完了");
+
+  // ── 完了レポート ──
+  console.log("\n=== OAS シードデータ投入完了 ===");
+  console.log("\nログイン情報:");
+  console.log("  [管理者]   admin@oas-test.local / Admin001!（パスワード変更不要）");
+  console.log("  [スタッフ] staff@oas-test.local / Staff001!（初回パスワード変更必要）");
+  console.log("\n予約サンプル:");
+  console.log(`  今日     (${dateStr(0)}): 3件（確定2 + 保留1）`);
+  console.log(`  明日     (${dateStr(1)}): 2件（保留2）`);
+  console.log(`  明後日   (${dateStr(2)}): 1件（キャンセル済み）`);
+
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error("シード投入エラー:", err);
+  process.exit(1);
+});

--- a/oas-spa/src/components/ui/Textarea.tsx
+++ b/oas-spa/src/components/ui/Textarea.tsx
@@ -7,7 +7,7 @@ interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ label, error, className, id, ...props }, ref) => {
+  ({ label, error, className, id, disabled, ...props }, ref) => {
     const textareaId = id || label?.replace(/\s/g, '-');
     return (
       <div className="space-y-1.5">
@@ -27,8 +27,10 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             'focus:outline-none focus:border-gold focus:shadow-[0_0_0_1px_#C9A96E]',
             'transition-all duration-200',
             error && 'border-danger focus:border-danger',
+            disabled && 'bg-cream-100 text-navy-300 cursor-not-allowed opacity-60',
             className,
           )}
+          disabled={disabled}
           {...props}
         />
         {error && <p className="text-xs text-danger">{error}</p>}

--- a/oas-spa/src/contexts/ClinicContext.tsx
+++ b/oas-spa/src/contexts/ClinicContext.tsx
@@ -26,6 +26,7 @@ const DEFAULT_CLINIC: ClinicSettings = {
   announcement: { active: false, type: 'info', message: '', startDate: null, endDate: null },
   maintenance: { startDate: null, endDate: null },
   privacyPolicy: '',
+  sensitiveDataConsentText: '',
   updatedAt: '',
 };
 

--- a/oas-spa/src/hooks/useReservation.ts
+++ b/oas-spa/src/hooks/useReservation.ts
@@ -37,6 +37,7 @@ export async function createReservation(
     symptoms: data.symptoms,
     notes: data.notes,
     contactMethod: data.contactMethod,
+    hasSensitiveDataConsent: data.hasSensitiveDataConsent,
   };
   const result = await callFunction<CreateResult>('createReservation', payload);
   return { bookingId: result.reservationId };

--- a/oas-spa/src/pages/admin/Settings.tsx
+++ b/oas-spa/src/pages/admin/Settings.tsx
@@ -164,6 +164,16 @@ function BasicInfoTab({ form, update }: { form: Partial<ClinicSettings>; update:
           <Input label="キャンセル締切（分前）" type="number" min={0} value={form.cancelCutoffMinutes ?? 60} onChange={e => update({ cancelCutoffMinutes: Number(e.target.value) })} />
         </div>
         <Textarea label="プライバシーポリシー" value={form.privacyPolicy || ''} onChange={e => update({ privacyPolicy: e.target.value })} rows={6} />
+        <div>
+          <Textarea
+            label="要配慮個人情報の同意文言"
+            value={form.sensitiveDataConsentText || ''}
+            onChange={e => update({ sensitiveDataConsentText: e.target.value.slice(0, 500) })}
+            rows={3}
+            placeholder="空欄の場合はデフォルト文言が使用されます"
+          />
+          <p className="text-[11px] text-navy-400 mt-1">予約フォームの症状入力欄に表示されます。{form.sensitiveDataConsentText ? `${form.sensitiveDataConsentText.length}/500文字` : '空欄=デフォルト文言'}</p>
+        </div>
       </CardBody>
     </Card>
   );

--- a/oas-spa/src/pages/booking/Index.tsx
+++ b/oas-spa/src/pages/booking/Index.tsx
@@ -33,6 +33,7 @@ const INITIAL_FORM: ReservationFormData = {
   symptoms: '',
   notes: '',
   contactMethod: '電話',
+  hasSensitiveDataConsent: false,
 };
 
 export default function BookingIndex() {

--- a/oas-spa/src/pages/booking/PatientForm.tsx
+++ b/oas-spa/src/pages/booking/PatientForm.tsx
@@ -9,6 +9,7 @@ import { toHankaku } from '@/utils/security';
 import { isValidPhone, isValidEmail, isValidFurigana, isValidZip } from '@/utils/validation';
 import { calcAge } from '@/utils/date';
 import { cn } from '@/utils/cn';
+import { useClinic } from '@/hooks/useClinic';
 import type { ReservationFormData, Gender, VisitType, InsuranceType, ContactMethod } from '@/types/reservation';
 
 interface Props {
@@ -19,11 +20,20 @@ interface Props {
   privacyPolicyUrl?: string;
 }
 
+/** 要配慮個人情報の同意デフォルト文言（settings/clinic.sensitiveDataConsentText 未設定時） */
+const DEFAULT_SENSITIVE_DATA_TEXT =
+  '「症状・お悩み」欄に入力される健康に関する情報は、個人情報保護法上の「要配慮個人情報」に該当する可能性があります。当院の予約対応・施術準備の目的でのみ使用し、ご本人の同意なく第三者に提供することはありません。';
+
 export function PatientForm({ form, onUpdate, onNext, onBack, privacyPolicyUrl }: Props) {
+  const { clinic } = useClinic();
   const [consent, setConsent] = useState(false);
   const [consentError, setConsentError] = useState(false);
+  const [sensitiveConsentError, setSensitiveConsentError] = useState(false);
   const [errors, setErrors] = useState<string[]>([]);
   const [zipMsg, setZipMsg] = useState('');
+
+  /** 要配慮個人情報の同意文言（管理画面で設定可能、未設定時はデフォルト） */
+  const sensitiveDataText = clinic?.sensitiveDataConsentText?.trim() || DEFAULT_SENSITIVE_DATA_TEXT;
   const onUpdateRef = useRef(onUpdate);
   onUpdateRef.current = onUpdate;
 
@@ -85,7 +95,9 @@ export function PatientForm({ form, onUpdate, onNext, onBack, privacyPolicyUrl }
     } else if (form.email.trim() && !isValidEmail(form.email)) {
       errs.push('メールアドレスの形式が正しくありません');
     }
+    if (!form.hasSensitiveDataConsent) errs.push('健康情報の取り扱いに同意してください');
     if (!form.symptoms.trim()) errs.push('症状・お悩みを入力してください');
+    setSensitiveConsentError(!form.hasSensitiveDataConsent);
     setConsentError(!consent);
     setErrors(errs);
     return errs.length === 0 && consent;
@@ -218,7 +230,45 @@ export function PatientForm({ form, onUpdate, onNext, onBack, privacyPolicyUrl }
             ]}
           />
         </div>
-        <Textarea label="症状・お悩み *" value={form.symptoms} onChange={e => onUpdate({ symptoms: e.target.value })} rows={3} placeholder="〇月〇日の〇時頃から、腰痛・肩こりなど" required />
+        {/* [C1] 要配慮個人情報の同意（個人情報保護法 第20条第2項） */}
+        <div className={cn(
+          'rounded-lg border p-4 transition-all duration-200',
+          sensitiveConsentError ? 'border-danger bg-red-50/50 shadow-[0_0_0_3px_rgba(194,91,86,0.08)]' : 'border-cream-300/60 bg-cream-50/50',
+          form.hasSensitiveDataConsent && !sensitiveConsentError && 'border-gold/40 bg-gold-50/30',
+        )}>
+          <div className="flex items-start gap-2 mb-2.5">
+            <svg className="w-4 h-4 shrink-0 mt-0.5 text-navy-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+            <span className="text-xs font-medium text-navy-500 uppercase tracking-wider">健康情報の取り扱いについて</span>
+          </div>
+          <p className="text-xs text-navy-500 leading-relaxed mb-3 ml-6">{sensitiveDataText}</p>
+          <label className="flex items-start gap-3 cursor-pointer group ml-3">
+            <input
+              type="checkbox"
+              checked={form.hasSensitiveDataConsent}
+              onChange={e => {
+                onUpdate({ hasSensitiveDataConsent: e.target.checked });
+                setSensitiveConsentError(false);
+                // 同意解除時に症状フィールドをクリア
+                if (!e.target.checked) onUpdate({ hasSensitiveDataConsent: false, symptoms: '' });
+              }}
+              className="mt-0.5 h-4 w-4 rounded border-cream-300 text-gold focus:ring-gold/30"
+            />
+            <span className="text-sm text-navy-600 group-hover:text-navy-700 transition-colors font-medium">
+              上記に同意のうえ、健康情報を入力します
+            </span>
+          </label>
+          {sensitiveConsentError && (
+            <p className="text-xs text-danger mt-2 ml-6 font-medium flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+              </svg>
+              健康情報の取り扱いに同意してください
+            </p>
+          )}
+        </div>
+        <Textarea label="症状・お悩み *" value={form.symptoms} onChange={e => onUpdate({ symptoms: e.target.value })} rows={3} placeholder="〇月〇日の〇時頃から、腰痛・肩こりなど" required disabled={!form.hasSensitiveDataConsent} />
         <Textarea label="伝達事項（任意）" value={form.notes} onChange={e => onUpdate({ notes: e.target.value })} rows={2} placeholder="アレルギー、服用中の薬など" />
       </div>
 

--- a/oas-spa/src/types/clinic.ts
+++ b/oas-spa/src/types/clinic.ts
@@ -50,6 +50,8 @@ export interface ClinicSettings {
   maintenance: MaintenanceConfig;
   /** プライバシーポリシー */
   privacyPolicy: string;
+  /** 要配慮個人情報の同意文言（C1: 個人情報保護法 第20条第2項対応） */
+  sensitiveDataConsentText: string;
   /** メタデータ */
   updatedAt: string;
 }

--- a/oas-spa/src/types/reservation.ts
+++ b/oas-spa/src/types/reservation.ts
@@ -34,6 +34,8 @@ export interface ReservationRecord {
   symptoms: string;
   notes: string;
   contactMethod: ContactMethod;
+  /** 要配慮個人情報の同意フラグ（C1: 個人情報保護法 第20条第2項） */
+  hasSensitiveDataConsent: boolean;
   /** メタデータ */
   createdAt: string;
 }
@@ -56,6 +58,8 @@ export interface ReservationFormData {
   symptoms: string;
   notes: string;
   contactMethod: ContactMethod;
+  /** 要配慮個人情報の同意フラグ（C1） */
+  hasSensitiveDataConsent: boolean;
 }
 
 /** 時間スロット（slots コレクション） */


### PR DESCRIPTION
## Summary
- 予約フォームの症状フィールドに要配慮個人情報（個人情報保護法 第20条第2項）の同意チェックを追加
- CF `createReservation` でサーバーサイド検証 + Firestore 証跡保存（`hasSensitiveDataConsent`）
- 管理画面 Settings に同意文言カスタマイズ用テキストエリア追加
- OAS エミュレーター用シードスクリプト新規作成（`functions/seed.js`）

## Changed Files (11)
| File | Change |
|---|---|
| `oas-spa/src/pages/booking/PatientForm.tsx` | 同意ブロック追加 + 症状disabled制御 |
| `oas-spa/src/types/clinic.ts` | `sensitiveDataConsentText` 追加 |
| `oas-spa/src/types/reservation.ts` | `hasSensitiveDataConsent` 追加 |
| `oas-spa/src/contexts/ClinicContext.tsx` | デフォルト値追加 |
| `oas-spa/src/hooks/useReservation.ts` | ペイロードにフラグ追加 |
| `oas-spa/src/pages/booking/Index.tsx` | 初期値追加 |
| `oas-spa/src/pages/admin/Settings.tsx` | 同意文言テキストエリア追加 |
| `oas-spa/src/components/ui/Textarea.tsx` | disabled スタイル追加 |
| `functions/index.js` | サーバーサイド検証 + 証跡保存 |
| `firestore.rules` | `isValidReservation` 拡張 |
| `functions/seed.js` | OAS テストデータスクリプト新規 |

## Test plan
- [ ] TC-01: 同意チェックなし → 症状フィールドdisabled
- [ ] TC-02: 同意チェックON → 症状入力 → 確認画面へ正常遷移
- [ ] TC-03: 同意チェックなしで「確認画面へ」→ エラー表示
- [ ] TC-06: API直接（hasSensitiveDataConsent なし）→ 400
- [ ] TC-07: API直接（hasSensitiveDataConsent: true）→ 予約成功 + フラグ保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)