### PR TITLE
[OAS-UX] 管理画面ダッシュボード改善

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -62,10 +62,17 @@ service cloud.firestore {
     match /users/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
       allow write: if isAdmin();
-      // 本人のみ mustChangePassword フィールドの更新可
+      // 本人のみ以下フィールドの更新可:
+      // - mustChangePassword: 初回パスワード変更完了時
+      // - [C2] termsAcceptedAt / privacyAcceptedAt / termsVersion: 利用規約・PP同意時
       allow update: if request.auth != null
         && request.auth.uid == userId
-        && request.resource.data.diff(resource.data).affectedKeys().hasOnly(['mustChangePassword']);
+        && request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+          'mustChangePassword',
+          'termsAcceptedAt',
+          'privacyAcceptedAt',
+          'termsVersion'
+        ]);
     }
 
     // 監査ログコレクション（CSVエクスポート等の操作記録）

--- a/functions/seed.js
+++ b/functions/seed.js
@@ -65,6 +65,29 @@ const CLINIC_SETTINGS = {
     "",
     "個人情報に関するお問い合わせは、受付窓口までお願いいたします。",
   ].join("\n"),
+  termsOfService: [
+    "第1条（目的）",
+    "本利用規約（以下「本規約」）は、テストクリニック（以下「当院」）が提供する予約管理システム（以下「本システム」）の利用条件を定めるものです。",
+    "",
+    "第2条（利用者）",
+    "本システムは、当院が承認した管理者およびスタッフ（以下「利用者」）が業務目的で利用するものとします。",
+    "",
+    "第3条（禁止事項）",
+    "利用者は、以下の行為を行ってはなりません。",
+    "1. 本システムを業務目的以外で使用すること",
+    "2. 患者の個人情報を不正に利用・漏洩すること",
+    "3. アカウント情報を第三者に共有すること",
+    "4. 本システムの機能を不正に操作すること",
+    "",
+    "第4条（個人情報の取り扱い）",
+    "利用者は、本システムで取り扱う患者情報が個人情報保護法に基づく要配慮個人情報を含むことを理解し、適切に管理するものとします。",
+    "",
+    "第5条（免責事項）",
+    "当院は、本システムの利用により生じた損害について、故意または重大な過失がある場合を除き、責任を負いません。",
+    "",
+    "第6条（規約の変更）",
+    "当院は、本規約を変更する場合、利用者に通知のうえ再同意を求めます。",
+  ].join("\n"),
   sensitiveDataConsentText: '',  // 空 = デフォルト文言使用
   updatedAt: new Date().toISOString(),
 };
@@ -76,12 +99,14 @@ const ADMIN_USERS = [
     password:    "Admin001!",
     displayName: "管理者テスト",
     mustChangePassword: false,  // テスト用 — すぐログイン可能
+    termsVersion: "1.0",        // [C2] 同意済み — モーダルスキップ
   },
   {
     email:       "staff@oas-test.local",
     password:    "Staff001!",
     displayName: "スタッフテスト",
     mustChangePassword: true,   // 初回パスワード変更フロー確認用
+    termsVersion: null,         // [C2] 未同意 — モーダル表示
   },
 ];
 
@@ -162,13 +187,17 @@ const SAMPLE_RESERVATIONS = [
 async function main() {
   console.log("=== OAS シードデータ投入開始 ===\n");
 
-  // 1. クリニック設定
-  console.log("[1/4] settings/clinic を作成...");
+  // 1. クリニック設定 + 利用規約バージョン
+  console.log("[1/5] settings/clinic + settings/terms を作成...");
   await db.collection("settings").doc("clinic").set(CLINIC_SETTINGS);
-  console.log("  ✓ クリニック設定作成完了");
+  await db.collection("settings").doc("terms").set({
+    currentVersion: "1.0",
+    updatedAt: new Date().toISOString(),
+  });
+  console.log("  ✓ クリニック設定 + 利用規約バージョン (v1.0) 作成完了");
 
   // 2. 管理者ユーザー（Auth + Firestore + カスタムクレーム）
-  console.log("[2/4] 管理者ユーザーを作成...");
+  console.log("[2/5] 管理者ユーザーを作成...");
   for (const u of ADMIN_USERS) {
     try {
       const rec = await auth.createUser({
@@ -177,13 +206,18 @@ async function main() {
         displayName: u.displayName,
       });
       await auth.setCustomUserClaims(rec.uid, { admin: true });
+      const now = new Date().toISOString();
       await db.collection("users").doc(rec.uid).set({
         uid:                 rec.uid,
         email:               u.email,
         displayName:         u.displayName,
         isAdmin:             true,
         mustChangePassword:  u.mustChangePassword,
-        createdAt:           new Date().toISOString(),
+        // [C2] 利用規約・PP同意フィールド
+        termsAcceptedAt:     u.termsVersion ? now : null,
+        privacyAcceptedAt:   u.termsVersion ? now : null,
+        termsVersion:        u.termsVersion || null,
+        createdAt:           now,
       });
       console.log(`  ✓ ${u.email} (UID: ${rec.uid}) — mustChangePassword: ${u.mustChangePassword}`);
     } catch (err) {
@@ -196,7 +230,7 @@ async function main() {
   }
 
   // 3. サンプル予約 + スロット
-  console.log("[3/4] サンプル予約・スロットを作成...");
+  console.log("[3/5] サンプル予約・スロットを作成...");
   for (const r of SAMPLE_RESERVATIONS) {
     const id     = crypto.randomUUID();
     const slotId = `${r.date}_${r.time.replace(":", "")}`;
@@ -234,7 +268,7 @@ async function main() {
   }
 
   // 4. 監査ログサンプル
-  console.log("[4/4] 監査ログサンプルを作成...");
+  console.log("[4/5] 監査ログサンプルを作成...");
   await db.collection("audit_logs").add({
     action:      "seed_executed",
     performedBy: "system",

--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -1,10 +1,13 @@
 import { Outlet, Navigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { useClinic } from '@/hooks/useClinic';
 import { Spinner } from '@/components/ui/Spinner';
 import { Button } from '@/components/ui/Button';
+import { ConsentModal } from '@/components/shared/ConsentModal';
 
 export function AdminLayout() {
-  const { user, isAdmin, loading, logout, profile } = useAuth();
+  const { user, isAdmin, loading, logout, profile, needsConsent, acceptConsent } = useAuth();
+  const { clinic } = useClinic();
   const location = useLocation();
 
   if (loading) return <Spinner overlay />;
@@ -77,6 +80,14 @@ export function AdminLayout() {
       <main className="flex-1 max-w-3xl mx-auto w-full px-4 py-6">
         <Outlet />
       </main>
+
+      {/* [C2] 利用規約・PP同意モーダル（未同意時はブロッキング表示） */}
+      <ConsentModal
+        open={needsConsent && !profile?.mustChangePassword}
+        termsText={clinic?.termsOfService || ''}
+        privacyText={clinic?.privacyPolicy || ''}
+        onAccept={acceptConsent}
+      />
     </div>
   );
 }

--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -23,7 +23,7 @@ export function AdminLayout() {
     <div className="min-h-screen flex flex-col bg-canvas">
       {/* 管理者ヘッダー — ダークネイビーで患者側と差別化 */}
       <header className="admin-header sticky top-0 z-40">
-        <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-4">
             <Link to="/admin" className="flex items-center gap-2.5 group">
               <span className="w-8 h-8 rounded-lg bg-white/10 flex items-center justify-center transition-colors group-hover:bg-white/15">
@@ -77,7 +77,7 @@ export function AdminLayout() {
         </div>
       </header>
 
-      <main className="flex-1 max-w-3xl mx-auto w-full px-4 py-6">
+      <main className="flex-1 max-w-5xl mx-auto w-full px-4 py-6">
         <Outlet />
       </main>
 

--- a/oas-spa/src/components/shared/ConsentModal.tsx
+++ b/oas-spa/src/components/shared/ConsentModal.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/Button';
+
+interface ConsentModalProps {
+  open: boolean;
+  termsText: string;
+  privacyText: string;
+  onAccept: () => Promise<void>;
+}
+
+/**
+ * [C2] 利用規約・プライバシーポリシー同意モーダル
+ *
+ * - 2ステップ: 利用規約 → プライバシーポリシー
+ * - スクロール末尾到達で「同意」ボタン有効化
+ * - Escape / バックドロップクリック無効（同意必須）
+ */
+export function ConsentModal({ open, termsText, privacyText, onAccept }: ConsentModalProps) {
+  const [step, setStep] = useState<1 | 2>(1);
+  const [scrolledToBottom, setScrolledToBottom] = useState(false);
+  const [accepting, setAccepting] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // モーダル表示時にリセット
+  useEffect(() => {
+    if (open) {
+      setStep(1);
+      setScrolledToBottom(false);
+      setAccepting(false);
+    }
+  }, [open]);
+
+  // ステップ切替時にスクロールリセット
+  useEffect(() => {
+    setScrolledToBottom(false);
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = 0;
+    }
+  }, [step]);
+
+  // テキストが短くスクロール不要な場合は即座に有効化
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // DOM更新後にチェック
+    requestAnimationFrame(() => {
+      if (el.scrollHeight <= el.clientHeight + 10) {
+        setScrolledToBottom(true);
+      }
+    });
+  }, [step, open]);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const isBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 20;
+    if (isBottom) setScrolledToBottom(true);
+  }, []);
+
+  async function handleAccept() {
+    if (step === 1) {
+      setStep(2);
+      return;
+    }
+    setAccepting(true);
+    try {
+      await onAccept();
+    } finally {
+      setAccepting(false);
+    }
+  }
+
+  // Escape キー無効化
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') e.preventDefault();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [open]);
+
+  if (!open) return null;
+
+  const currentText = step === 1 ? termsText : privacyText;
+  const stepLabel = step === 1 ? '利用規約' : 'プライバシーポリシー';
+  const buttonLabel = step === 1 ? '同意して次へ' : '同意して利用開始';
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60]">
+      {/* バックドロップ（クリック無効） */}
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+
+      {/* センタリング */}
+      <div className="absolute inset-0 flex items-center justify-center p-4">
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label={stepLabel}
+          className="relative bg-white rounded-xl shadow-2xl w-full max-w-lg animate-scale-in border border-cream-300/60 flex flex-col max-h-[85vh]"
+        >
+          {/* ヘッダー */}
+          <div className="px-5 py-4 border-b border-cream-300/60 shrink-0">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-heading font-semibold text-navy-700">
+                {stepLabel}
+              </h3>
+              {/* ステップインジケーター */}
+              <div className="flex items-center gap-1.5">
+                <span className={`w-2 h-2 rounded-full transition-colors ${step === 1 ? 'bg-gold' : 'bg-cream-300'}`} />
+                <span className={`w-2 h-2 rounded-full transition-colors ${step === 2 ? 'bg-gold' : 'bg-cream-300'}`} />
+              </div>
+            </div>
+            <p className="text-xs text-navy-400 mt-1">
+              ステップ {step} / 2 — 最後までお読みください
+            </p>
+          </div>
+
+          {/* スクロール可能なテキスト領域 */}
+          <div
+            ref={scrollRef}
+            onScroll={handleScroll}
+            className="flex-1 overflow-y-auto px-5 py-4 min-h-0"
+          >
+            <div className="text-sm text-navy-600 leading-relaxed whitespace-pre-wrap font-body">
+              {currentText || `（${stepLabel}が設定されていません）`}
+            </div>
+          </div>
+
+          {/* フッター */}
+          <div className="px-5 py-4 border-t border-cream-300/60 shrink-0 space-y-3">
+            {!scrolledToBottom && (
+              <p className="text-xs text-navy-400 text-center flex items-center justify-center gap-1.5">
+                <svg className="w-3.5 h-3.5 animate-bounce" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                </svg>
+                下までスクロールしてお読みください
+              </p>
+            )}
+            <Button
+              className="w-full"
+              disabled={!scrolledToBottom}
+              loading={accepting}
+              onClick={handleAccept}
+            >
+              {buttonLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/oas-spa/src/contexts/AuthContext.tsx
+++ b/oas-spa/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState, type ReactNode } from 'react';
+import { createContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import {
   onAuthStateChanged,
   signInWithEmailAndPassword,
@@ -17,10 +17,14 @@ interface AuthContextValue {
   profile: UserProfile | null;
   isAdmin: boolean;
   loading: boolean;
+  /** [C2] 利用規約・PP同意が必要か */
+  needsConsent: boolean;
   login: (email: string, password: string) => Promise<{ mustChangePassword: boolean }>;
   logout: () => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
   clearMustChangePassword: () => Promise<void>;
+  /** [C2] 利用規約・PP同意を記録 */
+  acceptConsent: () => Promise<void>;
   refreshProfile: () => Promise<void>;
 }
 
@@ -31,6 +35,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
+  /** [C2] settings/terms の currentVersion */
+  const [currentTermsVersion, setCurrentTermsVersion] = useState<string | null>(null);
 
   /** Firestore からプロフィールを取得 */
   async function fetchProfile(u: User): Promise<UserProfile | null> {
@@ -45,19 +51,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return data;
   }
 
+  /** [C2] settings/terms から最新バージョンを取得 */
+  async function fetchTermsVersion() {
+    const snap = await getDoc(doc(db, 'settings', 'terms'));
+    const ver = snap.exists() ? (snap.data().currentVersion as string) : null;
+    setCurrentTermsVersion(ver);
+    return ver;
+  }
+
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (u) => {
       setUser(u);
       if (u) {
-        await fetchProfile(u);
+        await Promise.all([fetchProfile(u), fetchTermsVersion()]);
       } else {
         setProfile(null);
         setIsAdmin(false);
+        setCurrentTermsVersion(null);
       }
       setLoading(false);
     });
     return unsubscribe;
   }, []);
+
+  /** [C2] 利用規約の同意が必要か判定 */
+  const needsConsent = useMemo(() => {
+    if (!profile || !currentTermsVersion) return false;
+    return profile.termsVersion !== currentTermsVersion;
+  }, [profile, currentTermsVersion]);
 
   async function login(email: string, password: string) {
     const cred = await signInWithEmailAndPassword(auth, email, password);
@@ -70,7 +91,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(cred.user);
     // 最終ログイン日時を記録
     updateDoc(doc(db, 'users', cred.user.uid), { lastLoginAt: serverTimestamp() }).catch(() => {});
-    const p = await fetchProfile(cred.user);
+    const [p] = await Promise.all([fetchProfile(cred.user), fetchTermsVersion()]);
     return { mustChangePassword: !!p?.mustChangePassword };
   }
 
@@ -92,16 +113,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setProfile(prev => prev ? { ...prev, mustChangePassword: false } : prev);
   }
 
+  /** [C2] 利用規約・PP同意を Firestore に記録 */
+  async function acceptConsent() {
+    if (!user || !currentTermsVersion) return;
+    const now = new Date().toISOString();
+    await updateDoc(doc(db, 'users', user.uid), {
+      termsAcceptedAt:  now,
+      privacyAcceptedAt: now,
+      termsVersion:      currentTermsVersion,
+    });
+    setProfile(prev => prev ? {
+      ...prev,
+      termsAcceptedAt:  now,
+      privacyAcceptedAt: now,
+      termsVersion:      currentTermsVersion,
+    } : prev);
+  }
+
   async function refreshProfile() {
-    if (user) await fetchProfile(user);
+    if (user) {
+      await Promise.all([fetchProfile(user), fetchTermsVersion()]);
+    }
   }
 
   return (
     <AuthContext.Provider value={{
-      user, profile, isAdmin, loading,
+      user, profile, isAdmin, loading, needsConsent,
       login, logout,
       changePassword: changePasswordFn,
       clearMustChangePassword,
+      acceptConsent,
       refreshProfile,
     }}>
       {children}

--- a/oas-spa/src/contexts/ClinicContext.tsx
+++ b/oas-spa/src/contexts/ClinicContext.tsx
@@ -25,6 +25,7 @@ const DEFAULT_CLINIC: ClinicSettings = {
   cancelCutoffMinutes: 0,
   announcement: { active: false, type: 'info', message: '', startDate: null, endDate: null },
   maintenance: { startDate: null, endDate: null },
+  termsOfService: '',
   privacyPolicy: '',
   sensitiveDataConsentText: '',
   updatedAt: '',

--- a/oas-spa/src/pages/admin/Dashboard.tsx
+++ b/oas-spa/src/pages/admin/Dashboard.tsx
@@ -39,10 +39,13 @@ export default function Dashboard() {
   const [search, setSearch] = useState('');
   const [phoneSearch, setPhoneSearch] = useState('');
   const [zipSearch, setZipSearch] = useState('');
+  const [createdAtFilter, setCreatedAtFilter] = useState('');
   const [kpiFilter, setKpiFilter] = useState<KpiFilter>(null);
 
   // 詳細モーダル
   const [selected, setSelected] = useState<ReservationRecord | null>(null);
+  // 症状モーダル
+  const [symptomsTarget, setSymptomsTarget] = useState<ReservationRecord | null>(null);
 
   // ステータス変更確認
   const [confirmAction, setConfirmAction] = useState<{ booking: ReservationRecord; status: ReservationStatus } | null>(null);
@@ -70,19 +73,20 @@ export default function Dashboard() {
     setSearch('');
     setPhoneSearch('');
     setZipSearch('');
+    setCreatedAtFilter('');
   }
 
   /** フィルター適用 */
   const filtered = useMemo(() => {
     let list = reservations;
 
-    // KPIフィルター
+    // KPIフィルター（KPI計算と同じくキャンセル済みを除外）
     if (kpiFilter === 'today') {
-      list = list.filter(r => r.date === todayStr);
+      list = list.filter(r => r.date === todayStr && r.status !== 'cancelled');
     } else if (kpiFilter === 'month') {
-      list = list.filter(r => r.date.startsWith(monthPrefix));
+      list = list.filter(r => r.date.startsWith(monthPrefix) && r.status !== 'cancelled');
     } else if (kpiFilter === 'new') {
-      list = list.filter(r => r.visitType === '初診');
+      list = list.filter(r => r.visitType === '初診' && r.date.startsWith(monthPrefix) && r.status !== 'cancelled');
     } else if (kpiFilter === 'pending') {
       list = list.filter(r => r.status === 'pending');
     } else {
@@ -103,8 +107,11 @@ export default function Dashboard() {
       const q = zipSearch.replace(/[-\s]/g, '');
       list = list.filter(r => (r.zip || '').replace(/[-\s]/g, '').includes(q));
     }
+    if (createdAtFilter) {
+      list = list.filter(r => r.createdAt && r.createdAt.startsWith(createdAtFilter));
+    }
     return list;
-  }, [reservations, statusFilter, dateFilter, search, phoneSearch, zipSearch, kpiFilter, todayStr, monthPrefix]);
+  }, [reservations, statusFilter, dateFilter, search, phoneSearch, zipSearch, createdAtFilter, kpiFilter, todayStr, monthPrefix]);
 
   /** 通常フィルター操作時はKPIフィルターをクリア */
   function setStatusFilterAndClearKpi(s: ReservationStatus | 'all') {
@@ -118,10 +125,11 @@ export default function Dashboard() {
     setSearch('');
     setPhoneSearch('');
     setZipSearch('');
+    setCreatedAtFilter('');
     setKpiFilter(null);
   }
 
-  const hasFilter = dateFilter || search || phoneSearch || zipSearch || statusFilter !== 'all' || kpiFilter;
+  const hasFilter = dateFilter || createdAtFilter || search || phoneSearch || zipSearch || statusFilter !== 'all' || kpiFilter;
 
   /** ステータス更新 */
   async function handleStatusUpdate() {
@@ -175,8 +183,9 @@ export default function Dashboard() {
 
       {/* フィルター + CSV */}
       <Card>
-        <CardBody>
-          <div className="flex flex-wrap items-end gap-3">
+        <CardBody className="space-y-3">
+          {/* 1段目: ステータスタブ */}
+          <div className="flex items-center justify-between">
             <div className="flex gap-1">
               {(['all', 'pending', 'confirmed', 'cancelled'] as const).map(s => (
                 <Button
@@ -189,38 +198,6 @@ export default function Dashboard() {
                 </Button>
               ))}
             </div>
-            <Input
-              type="date"
-              value={dateFilter}
-              onChange={e => { setDateFilter(e.target.value); setKpiFilter(null); }}
-              className="w-40"
-            />
-            <Input
-              placeholder="氏名検索"
-              value={search}
-              onChange={e => setSearch(e.target.value)}
-              className="w-32"
-            />
-            <Input
-              placeholder="電話番号"
-              value={phoneSearch}
-              onChange={e => setPhoneSearch(e.target.value)}
-              className="w-32"
-            />
-            <Input
-              placeholder="郵便番号"
-              value={zipSearch}
-              onChange={e => setZipSearch(e.target.value)}
-              className="w-28"
-            />
-          </div>
-          <div className="flex items-center mt-2">
-            {hasFilter && (
-              <Button size="sm" variant="ghost" onClick={clearFilters}>
-                クリア
-              </Button>
-            )}
-            <div className="flex-1" />
             <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(filtered)}>
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -228,6 +205,44 @@ export default function Dashboard() {
               CSV出力
             </Button>
           </div>
+          {/* 2段目: 検索フィールド */}
+          <div className="grid grid-cols-5 gap-2">
+            <Input
+              label="氏名"
+              placeholder="山田太郎"
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <Input
+              label="郵便番号"
+              placeholder="123-4567"
+              value={zipSearch}
+              onChange={e => setZipSearch(e.target.value)}
+            />
+            <Input
+              label="電話番号"
+              placeholder="090-1234-5678"
+              value={phoneSearch}
+              onChange={e => setPhoneSearch(e.target.value)}
+            />
+            <Input
+              label="予約受付日"
+              type="date"
+              value={createdAtFilter}
+              onChange={e => { setCreatedAtFilter(e.target.value); setKpiFilter(null); }}
+            />
+            <Input
+              label="診察予定日"
+              type="date"
+              value={dateFilter}
+              onChange={e => { setDateFilter(e.target.value); setKpiFilter(null); }}
+            />
+          </div>
+          {hasFilter && (
+            <Button size="sm" variant="ghost" onClick={clearFilters}>
+              クリア
+            </Button>
+          )}
         </CardBody>
       </Card>
 
@@ -248,7 +263,7 @@ export default function Dashboard() {
             <table className="w-full text-sm border-separate border-spacing-0">
               <thead>
                 <tr className="border-b border-cream-200">
-                  {['日時', '氏名', '初/再', '症状', '電話', 'ステータス', ''].map(h => (
+                  {['診察予定日時', '氏名', '初/再', '症状', '電話', '予約受付日', 'ステータス', ''].map(h => (
                     <th key={h} className="px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50 first:rounded-tl-lg last:rounded-tr-lg">{h}</th>
                   ))}
                 </tr>
@@ -268,10 +283,24 @@ export default function Dashboard() {
                         {r.visitType || '-'}
                       </Badge>
                     </td>
-                    <td className="px-3 py-3 max-w-[160px] truncate text-navy-500" title={r.symptoms}>
-                      {r.symptoms}
+                    <td className="px-3 py-3 max-w-[160px]">
+                      {r.symptoms ? (
+                        <button
+                          type="button"
+                          onClick={() => setSymptomsTarget(r)}
+                          className="text-left text-sky-600 hover:text-sky-800 hover:underline truncate block max-w-full transition-colors"
+                          title={r.symptoms}
+                        >
+                          {r.symptoms}
+                        </button>
+                      ) : (
+                        <span className="text-navy-300">-</span>
+                      )}
                     </td>
                     <td className="px-3 py-3 whitespace-nowrap text-navy-500 font-mono text-xs">{r.phone}</td>
+                    <td className="px-3 py-3 whitespace-nowrap text-navy-400 text-xs">
+                      {r.createdAt ? new Date(r.createdAt).toLocaleDateString('ja-JP') : '-'}
+                    </td>
                     <td className="px-3 py-3 whitespace-nowrap">
                       <Badge className={STATUS_BADGE[r.status].cls}>{STATUS_BADGE[r.status].label}</Badge>
                     </td>
@@ -298,10 +327,11 @@ export default function Dashboard() {
           <dl className="space-y-1 text-sm mb-6">
             {[
               ['予約番号', selected.id],
-              ['予約日時', formatDateTimeJa(selected.date, selected.time)],
+              ['診察予定日時', formatDateTimeJa(selected.date, selected.time)],
               ['氏名', selected.name],
               ['ふりがな', selected.furigana],
               ['生年月日', selected.birthdate + (calcAge(selected.birthdate) !== null ? `（${calcAge(selected.birthdate)}歳）` : '')],
+              ['郵便番号', selected.zip || '-'],
               ['住所', selected.address],
               ['電話番号', selected.phone],
               ['メール', selected.email || '-'],
@@ -312,7 +342,7 @@ export default function Dashboard() {
               ['伝達事項', selected.notes || 'なし'],
               ['連絡方法', selected.contactMethod || '-'],
               ['ステータス', STATUS_BADGE[selected.status].label],
-              ['登録日時', selected.createdAt ? new Date(selected.createdAt).toLocaleString('ja-JP') : '-'],
+              ['予約受付日', selected.createdAt ? new Date(selected.createdAt).toLocaleString('ja-JP') : '-'],
             ].map(([label, val]) => (
               <div key={label} className="flex border-b border-cream-200/80 py-2">
                 <dt className="w-24 shrink-0 text-navy-400">{label}</dt>
@@ -341,6 +371,19 @@ export default function Dashboard() {
               </Button>
             )}
           </div>
+        </Modal>
+      )}
+
+      {/* 症状モーダル */}
+      {symptomsTarget && (
+        <Modal open={!!symptomsTarget} onClose={() => setSymptomsTarget(null)} title={`${symptomsTarget.name}様 — 症状`}>
+          <p className="text-sm text-navy-700 whitespace-pre-wrap leading-relaxed">{symptomsTarget.symptoms}</p>
+          {symptomsTarget.notes && (
+            <div className="mt-4 pt-3 border-t border-cream-200">
+              <p className="text-[11px] text-navy-400 mb-1">伝達事項</p>
+              <p className="text-sm text-navy-600 whitespace-pre-wrap">{symptomsTarget.notes}</p>
+            </div>
+          )}
         </Modal>
       )}
 

--- a/oas-spa/src/pages/admin/Settings.tsx
+++ b/oas-spa/src/pages/admin/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { doc, setDoc } from 'firebase/firestore';
+import { doc, setDoc, getDoc } from 'firebase/firestore';
 import { db } from '@/lib/firebase';
 import { useClinic } from '@/hooks/useClinic';
 import { useToast } from '@/hooks/useToast';
@@ -19,7 +19,7 @@ import { cn } from '@/utils/cn';
 import type { ClinicSettings, DaySchedule } from '@/types/clinic';
 import { DEFAULT_BUSINESS_HOURS } from '@/types/clinic';
 
-const TABS = ['基本情報', '営業時間', '休日', 'お知らせ', 'アカウント'] as const;
+const TABS = ['基本情報', '営業時間', '休日', 'お知らせ', '利用規約', 'アカウント'] as const;
 type Tab = typeof TABS[number];
 const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
 
@@ -92,6 +92,9 @@ export default function Settings() {
 
       {/* お知らせ */}
       {tab === 'お知らせ' && <AnnouncementTab form={form} update={update} />}
+
+      {/* 利用規約 */}
+      {tab === '利用規約' && <TermsTab form={form} update={update} />}
 
       {/* アカウント */}
       {tab === 'アカウント' && <AccountsTab adminUsers={adminUsers} />}
@@ -472,6 +475,93 @@ function AnnouncementTab({ form, update }: { form: Partial<ClinicSettings>; upda
           <div className="grid grid-cols-2 gap-3">
             <Input label="開始日時" type="datetime-local" value={maint.startDate || ''} onChange={e => updateMaint({ startDate: e.target.value || null })} />
             <Input label="終了日時" type="datetime-local" value={maint.endDate || ''} onChange={e => updateMaint({ endDate: e.target.value || null })} />
+          </div>
+        </CardBody>
+      </Card>
+    </div>
+  );
+}
+
+/* ── 利用規約タブ（C2） ── */
+function TermsTab({ form, update }: { form: Partial<ClinicSettings>; update: (p: Partial<ClinicSettings>) => void }) {
+  const { showToast } = useToast();
+  const [termsVersion, setTermsVersion] = useState('');
+  const [termsUpdatedAt, setTermsUpdatedAt] = useState('');
+  const [bumping, setBumping] = useState(false);
+
+  // settings/terms からバージョン情報取得
+  useEffect(() => {
+    getDoc(doc(db, 'settings', 'terms')).then(snap => {
+      if (snap.exists()) {
+        setTermsVersion(snap.data().currentVersion || '1.0');
+        setTermsUpdatedAt(snap.data().updatedAt || '');
+      } else {
+        setTermsVersion('1.0');
+      }
+    }).catch(() => {});
+  }, []);
+
+  /** バージョン更新（全管理者に再同意を要求） */
+  async function handleBumpVersion() {
+    const parts = termsVersion.split('.');
+    const minor = parseInt(parts[1] || '0', 10) + 1;
+    const newVer = `${parts[0]}.${minor}`;
+    setBumping(true);
+    try {
+      await setDoc(doc(db, 'settings', 'terms'), {
+        currentVersion: newVer,
+        updatedAt: new Date().toISOString(),
+      });
+      setTermsVersion(newVer);
+      setTermsUpdatedAt(new Date().toISOString());
+      showToast(`バージョンを ${newVer} に更新しました。全管理者に再同意が求められます。`, 'success');
+    } catch {
+      showToast('バージョン更新に失敗しました', 'error');
+    } finally {
+      setBumping(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-medium text-navy-700">利用規約</h3>
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-navy-400 tabular-nums">
+                v{termsVersion}
+                {termsUpdatedAt && ` (${new Date(termsUpdatedAt).toLocaleDateString('ja-JP')} 更新)`}
+              </span>
+            </div>
+          </div>
+        </CardHeader>
+        <CardBody className="space-y-4">
+          <Textarea
+            label="利用規約テキスト"
+            value={form.termsOfService || ''}
+            onChange={e => update({ termsOfService: e.target.value })}
+            rows={10}
+            placeholder="管理者がログイン時に同意する利用規約を入力してください"
+          />
+          <p className="text-[11px] text-navy-400">
+            管理者の初回ログイン時、またはバージョン更新後に表示されます。
+          </p>
+        </CardBody>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h3 className="text-sm font-medium text-navy-700">バージョン管理</h3>
+        </CardHeader>
+        <CardBody className="space-y-3">
+          <Alert variant="warning">
+            バージョンを更新すると、全管理者が次回ログイン時に利用規約・プライバシーポリシーへの再同意を求められます。
+          </Alert>
+          <div className="flex items-center gap-3">
+            <Button size="sm" variant="ghost" onClick={handleBumpVersion} loading={bumping}>
+              バージョンを更新（v{termsVersion} → v{termsVersion.split('.')[0]}.{parseInt(termsVersion.split('.')[1] || '0', 10) + 1}）
+            </Button>
           </div>
         </CardBody>
       </Card>

--- a/oas-spa/src/types/clinic.ts
+++ b/oas-spa/src/types/clinic.ts
@@ -48,6 +48,8 @@ export interface ClinicSettings {
   /** 表示・通知 */
   announcement: Announcement;
   maintenance: MaintenanceConfig;
+  /** [C2] 利用規約テキスト */
+  termsOfService: string;
   /** プライバシーポリシー */
   privacyPolicy: string;
   /** 要配慮個人情報の同意文言（C1: 個人情報保護法 第20条第2項対応） */

--- a/oas-spa/src/types/user.ts
+++ b/oas-spa/src/types/user.ts
@@ -5,6 +5,12 @@ export interface UserProfile {
   displayName?: string;
   isAdmin: boolean;
   mustChangePassword: boolean;
+  /** [C2] 利用規約同意日時（ISO 8601） */
+  termsAcceptedAt?: string | null;
+  /** [C2] プライバシーポリシー同意日時（ISO 8601） */
+  privacyAcceptedAt?: string | null;
+  /** [C2] 同意済みバージョン */
+  termsVersion?: string | null;
   createdAt: string;
   lastLoginAt?: string;
 }


### PR DESCRIPTION
## Summary
- 管理画面の横幅拡大、テーブルカラム追加・リネーム、検索セクション整理
- KPIフィルタークリック時のカウント不一致バグ修正
- 症状クリック→モーダル表示（AMS方式）

## Changes (2 files)
- `AdminLayout.tsx` — max-w-3xl → max-w-5xl
- `Dashboard.tsx` — テーブル/検索/モーダル全面改善

## Test plan
- [ ] 一覧: 「診察予定日時」「予約受付日」カラム表示、「詳細」ボタン見切れなし
- [ ] 症状クリック → モーダルで全文+伝達事項表示
- [ ] KPIカード「新規患者」クリック → 表示件数とKPI数値が一致
- [ ] 検索5フィールドが段揃えで整列
- [ ] 詳細モーダル: 郵便番号あり、ラベルが一覧と統一

🤖 Generated with [Claude Code](https://claude.ai/code)