### PR TITLE
[OAS] キャンセルフロー改修 + 予約一覧ソート + UI/UX改善

### DIFF
--- a/documents/REMAINING_TASKS.md
+++ b/documents/REMAINING_TASKS.md
@@ -27,8 +27,12 @@
 | ✅ | LEGAL-H3 | 患者権利行使機能（開示・訂正・利用停止） | P2 |
 | ✅ | LEGAL-M1 | 利用規約タブ（Settings画面）— C2で実装済 | P3 |
 | ⬜ | LEGAL-M2 | PPデフォルトテンプレート | P3 |
+| ✅ | OAS-UX-T02 | キャンセルフロー改修（管理者強制理由入力+患者通知、患者任意理由+管理者通知） | P1 |
+| ✅ | OAS-UX-T03 | 予約一覧ソート（SortableHeader、AMS移植） | P2 |
+| ✅ | OAS-UX-T04 | UI/UX改善（ペンディングバッジ、モーダルスクロール、最終ログイン表示、アナウンスバナー改行） | P2 |
+| ✅ | OAS-UX-T05 | ポリシー再生成機能（確認ダイアログ付き） | P2 |
 | ⬜ | OAS-UX-T01 | 管理ヘッダーにTOS確認アイコン（低優先） | P3 |
-| ⬜ | OAS-FUTURE-T01 | 多国語対応（7か国語、AMS同等） | P3 |
+| ⬜ | OAS-FUTURE-T01 | 多国語対応（i18n）— 7か国語、AMS同等 — 次セッションで着手予定 | P2 |
 | ⬜ | OAS-FUTURE-T02 | 顧客管理システム（新規プロジェクト候補） | P3 |
 
 ## Security (SEC) — Remaining
@@ -51,4 +55,4 @@
 | ⬜ | CR-PR7 | iframe sandbox 属性追加 | P3 |
 | ⬜ | CR-PR7 | 時刻フォーマットのゼロパディング互換性確認 | P3 |
 
-**Completed: 24 / Remaining: 11**
+**Completed: 29 / Remaining: 11**

--- a/documents/WORKLOG.md
+++ b/documents/WORKLOG.md
@@ -11,6 +11,65 @@
 
 ---
 
+## 2026-03-24 Work Log (4)
+
+### Completed Tasks
+
+#### [OAS-UX] Cancel Flow Overhaul (PR #8)
+
+- **Admin cancel**: Mandatory cancel reason input + patient email notification via Resend
+- **Patient cancel**: Optional cancel reason (health-related reasons excluded per APPI — not collected to avoid sensitive personal data), admin email notification on patient cancel
+- **Cancel link in confirmation email**: Added `/cancel?id=XXX` deep link to confirmation emails using `getOasBaseUrl()` helper function
+- **Firestore audit fields**: Added `cancelledBy`, `cancelReason`, and `cancelledAt` to reservation records for operational transparency and audit trail
+- **Cloud Function `cancelReservation`**: Added `secrets: [resendApiKey]`, dual-path logic (admin vs. patient), email notification helper functions
+
+#### [OAS-UX] SortableHeader Component (ported from AMS)
+
+- Multi-column sort with cycle: asc → desc → remove
+- Navy/cream/gold theme consistent with OAS design system
+
+#### [OAS-UX] Dashboard UX Improvements
+
+- Pending reservation badge with filter link (using `useSearchParams`)
+- Sortable table headers using SortableHeader component
+
+#### [OAS-UX] Detail Modal
+
+- Scrollable content area with fixed footer buttons (`max-h-[85vh] overflow-y-auto`)
+
+#### [OAS-UX] AdminLayout
+
+- Last login display with Firestore Timestamp → Date conversion
+- Notification badge for pending reservations
+
+#### [OAS-UX] PatientLayout
+
+- Announcement banner line break support via `whitespace-pre-line`
+
+#### [OAS-UX] Settings: Policy Auto-Generate "Regenerate" Feature
+
+- "Regenerate" button with confirmation dialog for privacy policy auto-generation
+- Privacy policy purpose updated to include anonymized statistical analysis
+
+#### [OAS-UX] Patient Cancel Page Bug Fix
+
+- Fixed missing free-text input box for "その他" (other) cancel reason — implementation oversight
+
+### Code Review
+
+- PR #8 created, code review in progress
+
+### Changed Files
+- `functions/index.js` — cancelReservation dual-path + email helpers + resendApiKey secret
+- `oas-spa/src/pages/admin/Dashboard.tsx` — sortable headers, pending badge, filter link
+- `oas-spa/src/pages/admin/AdminLayout.tsx` — last login display, notification badge
+- `oas-spa/src/pages/booking/PatientLayout.tsx` — whitespace-pre-line banner
+- `oas-spa/src/pages/booking/Cancel.tsx` — patient cancel reason + "その他" text input fix
+- `oas-spa/src/pages/admin/Settings.tsx` — policy regenerate + privacy purpose update
+- `oas-spa/src/components/ui/SortableHeader.tsx` — new component (ported from AMS)
+
+---
+
 ## 2026-03-24 Work Log (3)
 
 ### Completed Tasks

--- a/functions/index.js
+++ b/functions/index.js
@@ -37,6 +37,13 @@ function isRateLimited(ip) {
 
 const resendApiKey = defineSecret("RESEND_API_KEY");
 
+/** OAS予約システムのベースURL（メール内リンク用） */
+function getOasBaseUrl() {
+  return process.env.FUNCTIONS_EMULATOR === "true"
+    ? "http://localhost:5174"
+    : "https://oas.kojinius.jp";
+}
+
 // ── [SEC-14] 監査ログ（Cloud Logging へ構造化ログ出力）──
 function auditLog(event, data = {}) {
   // 個人情報を含まない構造化ログ。Cloud Functions は console.log を GCP Cloud Logging に転送する
@@ -336,11 +343,11 @@ exports.verifyReservation = onRequest(
 /**
  * 【SEC-5】予約キャンセル（サーバーサイド電話番号検証 + スロット開放）
  * POST /cancelReservation
- * Body: { reservationId, phone }
+ * Body: { reservationId, phone, cancelReason?, cancelledBy? }
  * レート制限: IP あたり 5回/分
  */
 exports.cancelReservation = onRequest(
-  { invoker: "public" },
+  { invoker: "public", secrets: [resendApiKey] },
   async (req, res) => {
     setCorsHeaders(req, res);
 
@@ -354,7 +361,9 @@ exports.cancelReservation = onRequest(
       return;
     }
 
-    const { reservationId, phone } = req.body;
+    const { reservationId, phone, cancelReason, cancelledBy } = req.body;
+    const by = cancelledBy === "admin" ? "admin" : "patient";
+    const reason = (typeof cancelReason === "string" ? cancelReason.slice(0, 200) : "") || "";
 
     // ── 必須フィールド検証 ──
     if (!reservationId || typeof reservationId !== "string" || reservationId.length > 100) {
@@ -395,19 +404,21 @@ exports.cancelReservation = onRequest(
         return;
       }
 
-      // ── キャンセル期限チェック（settings/clinic の cancelCutoffMinutes）──
+      // ── キャンセル期限チェック（患者キャンセルのみ適用、管理者は制限なし）──
       const settings       = await getClinicSettings();
-      const cutoffMinutes  = settings.cancelCutoffMinutes ?? 60;
-      const [bY, bM, bD]  = booking.date.split("-").map(Number);
-      const [bH, bMin]    = booking.time.split(":").map(Number);
-      const bookingMs      = new Date(bY, bM - 1, bD, bH, bMin).getTime();
-      const cutoffMs       = cutoffMinutes * 60 * 1000;
+      if (by === "patient") {
+        const cutoffMinutes  = settings.cancelCutoffMinutes ?? 60;
+        const [bY, bM, bD]  = booking.date.split("-").map(Number);
+        const [bH, bMin]    = booking.time.split(":").map(Number);
+        const bookingMs      = new Date(bY, bM - 1, bD, bH, bMin).getTime();
+        const cutoffMs       = cutoffMinutes * 60 * 1000;
 
-      if (Date.now() >= bookingMs - cutoffMs) {
-        res.status(400).json({
-          error: `予約時刻の${cutoffMinutes}分前を過ぎているため、オンラインではキャンセルできません。お電話にてご連絡ください。`,
-        });
-        return;
+        if (Date.now() >= bookingMs - cutoffMs) {
+          res.status(400).json({
+            error: `予約時刻の${cutoffMinutes}分前を過ぎているため、オンラインではキャンセルできません。お電話にてご連絡ください。`,
+          });
+          return;
+        }
       }
 
       // ── [SEC-8] トランザクションで予約+スロットを同時キャンセル（TOCTOU防止のため内部で再確認）──
@@ -424,14 +435,48 @@ exports.cancelReservation = onRequest(
           throw alreadyCancelled;
         }
 
-        tx.update(resRef, { status: "cancelled" });
+        tx.update(resRef, {
+          status: "cancelled",
+          cancelledBy: by,
+          cancelReason: reason,
+          cancelledAt: new Date().toISOString(),
+        });
 
         if (slotSnap.exists && slotSnap.data().status !== "cancelled") {
           tx.update(slotRef, { status: "cancelled" });
         }
       });
 
-      auditLog("reservation.cancelled", { reservationId });
+      auditLog("reservation.cancelled", { reservationId, cancelledBy: by, cancelReason: reason });
+
+      // ── キャンセル通知メール ──
+      try {
+        if (by === "admin" && booking.email) {
+          // 管理者キャンセル → 患者に通知（理由含む）
+          await _sendCancellationEmail({
+            to: booking.email,
+            name: booking.name,
+            date: booking.date,
+            time: booking.time,
+            reason,
+            settings,
+          });
+        }
+        if (by === "patient") {
+          // 患者キャンセル → 管理者に通知
+          await _notifyAdminOnCancellation({
+            id: reservationId,
+            name: booking.name,
+            date: booking.date,
+            time: booking.time,
+            reason,
+          });
+        }
+      } catch (mailErr) {
+        console.error("[cancelReservation] キャンセル通知メール送信失敗:", mailErr);
+        // メール失敗でもキャンセル自体は成功
+      }
+
       res.status(200).json({ success: true, message: "予約をキャンセルしました" });
     } catch (err) {
       if (err.message === "ALREADY_CANCELLED") {
@@ -482,8 +527,9 @@ async function _sendReservationEmail({ to, name, date, time, menu, id }) {
           </table>
           <div style="background:#fff8f0;border-left:4px solid #f5913e;padding:12px 16px;margin-bottom:24px;">
             <p style="margin:0 0 8px;font-weight:bold;">キャンセルについて</p>
-            <p style="margin:0;font-size:14px;">ご予約のキャンセル・変更は、お電話にてご連絡ください。<br>
-              <strong>電話番号：${escHtml(ph)}</strong>（受付時間：診療時間内）</p>
+            <p style="margin:0 0 8px;font-size:14px;">ご予約のキャンセルは下記リンクから手続きできます。</p>
+            <p style="margin:0 0 8px;"><a href="${getOasBaseUrl()}/cancel?id=${encodeURIComponent(id)}" style="display:inline-block;background:#72586f;color:#fff;padding:8px 16px;border-radius:6px;font-size:13px;text-decoration:none;">予約をキャンセルする</a></p>
+            <p style="margin:0;font-size:12px;color:#888;">お電話でもキャンセルを承ります: <strong>${escHtml(ph)}</strong>（受付時間：診療時間内）</p>
           </div>
           <p>ご不明な点がございましたら、お気軽にお問い合わせください。</p>
         </div>
@@ -497,6 +543,99 @@ async function _sendReservationEmail({ to, name, date, time, menu, id }) {
       </div>
     `,
   });
+}
+
+/**
+ * 【3-3】キャンセル通知メール（管理者キャンセル時に患者へ送信）
+ * @param {{ to: string, name: string, date: string, time: string, reason: string, settings: object }} params
+ */
+async function _sendCancellationEmail({ to, name, date, time, reason, settings }) {
+  const resend = new Resend(resendApiKey.value());
+  const cn = settings.clinicName || '院名未設定';
+  const ph = settings.phone || '';
+
+  await sendMail(resend, {
+    from:    `${escHtml(cn)} <noreply@kojinius.jp>`,
+    to,
+    subject: `【${escHtml(cn)}】ご予約キャンセルのお知らせ`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#333;">
+        <div style="background:#72586f;padding:24px 32px;">
+          <h1 style="margin:0;color:#fff;font-size:20px;">ご予約キャンセルのお知らせ</h1>
+        </div>
+        <div style="padding:24px 32px;">
+          <p>${escHtml(name)} 様</p>
+          <p>誠に申し訳ございませんが、以下のご予約がキャンセルとなりました。</p>
+          <table style="border-collapse:collapse;width:100%;margin-bottom:24px;">
+            <tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;width:30%;font-weight:bold;">日時</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;">${escHtml(date)} ${escHtml(time)}〜</td>
+            </tr>
+            ${reason ? `<tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;font-weight:bold;">理由</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;">${escHtml(reason)}</td>
+            </tr>` : ''}
+          </table>
+          <p>ご不便をおかけし申し訳ございません。改めてのご予約をお待ちしております。</p>
+          ${ph ? `<p style="font-size:14px;">ご不明な点がございましたら、お電話にてお問い合わせください。<br><strong>電話番号：${escHtml(ph)}</strong></p>` : ''}
+        </div>
+        <div style="background:#f5f5f5;padding:16px 32px;">
+          <p style="margin:0;color:#888;font-size:12px;">${escHtml(cn)} 予約システム</p>
+        </div>
+      </div>
+    `,
+  });
+}
+
+/**
+ * 【3-4】患者キャンセル時の管理者通知（内部ヘルパー）
+ * [SEC-10] 件名に患者名を含めない
+ */
+async function _notifyAdminOnCancellation({ id, name, date, time, reason }) {
+  const resend = new Resend(resendApiKey.value());
+  const [{ clinicName: cn = '院名未設定' }, adminEmails] = await Promise.all([
+    getClinicSettings(),
+    getAdminEmails(),
+  ]);
+  if (adminEmails.length === 0) return;
+
+  await Promise.all(adminEmails.map(to => sendMail(resend, {
+    from:    `${escHtml(cn)} <noreply@kojinius.jp>`,
+    to,
+    subject: `【キャンセル】予約がキャンセルされました`,
+    html: `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;color:#333;">
+        <div style="background:#c0392b;padding:24px 32px;">
+          <h1 style="margin:0;color:#fff;font-size:20px;">予約キャンセル通知</h1>
+        </div>
+        <div style="padding:24px 32px;">
+          <p>患者様から予約のキャンセルがありました。</p>
+          <table style="border-collapse:collapse;width:100%;margin-bottom:24px;">
+            <tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;width:30%;font-weight:bold;">予約番号</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;font-family:monospace;">${escHtml(id || '-')}</td>
+            </tr>
+            <tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;font-weight:bold;">日時</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;">${escHtml(date)} ${escHtml(time)}〜</td>
+            </tr>
+            <tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;font-weight:bold;">患者名</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;">${escHtml(name)}</td>
+            </tr>
+            ${reason ? `<tr>
+              <td style="padding:10px 12px;border:1px solid #ddd;background:#f9f9f9;font-weight:bold;">理由</td>
+              <td style="padding:10px 12px;border:1px solid #ddd;">${escHtml(reason)}</td>
+            </tr>` : ''}
+          </table>
+          <p style="color:#888;font-size:13px;">該当の時間枠は再予約可能になりました。</p>
+        </div>
+        <div style="background:#f5f5f5;padding:16px 32px;">
+          <p style="margin:0;color:#888;font-size:12px;">${escHtml(cn)} 予約システム</p>
+        </div>
+      </div>
+    `,
+  })));
 }
 
 /**

--- a/functions/index.js
+++ b/functions/index.js
@@ -343,7 +343,8 @@ exports.verifyReservation = onRequest(
 /**
  * 【SEC-5】予約キャンセル（サーバーサイド電話番号検証 + スロット開放）
  * POST /cancelReservation
- * Body: { reservationId, phone, cancelReason?, cancelledBy? }
+ * Body: { reservationId, phone, cancelReason? }
+ * Headers: Authorization: Bearer <idToken> （管理者キャンセル時のみ）
  * レート制限: IP あたり 5回/分
  */
 exports.cancelReservation = onRequest(
@@ -361,9 +362,18 @@ exports.cancelReservation = onRequest(
       return;
     }
 
-    const { reservationId, phone, cancelReason, cancelledBy } = req.body;
-    const by = cancelledBy === "admin" ? "admin" : "patient";
+    const { reservationId, phone, cancelReason } = req.body;
     const reason = (typeof cancelReason === "string" ? cancelReason.slice(0, 200) : "") || "";
+
+    // ── [SEC-CR1] cancelledBy はサーバー側で判定（クライアント信用しない）──
+    let by = "patient";
+    const authHeader = req.headers.authorization;
+    if (authHeader?.startsWith("Bearer ")) {
+      try {
+        const decoded = await getAuth().verifyIdToken(authHeader.split("Bearer ")[1]);
+        if (decoded.admin) by = "admin";
+      } catch (_) { /* トークン不正 → 患者扱い */ }
+    }
 
     // ── 必須フィールド検証 ──
     if (!reservationId || typeof reservationId !== "string" || reservationId.length > 100) {

--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, Navigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
 import { useClinic } from '@/hooks/useClinic';
+import { usePendingCount } from '@/hooks/useAdmin';
 import { Spinner } from '@/components/ui/Spinner';
 import { Button } from '@/components/ui/Button';
 import { ConsentModal } from '@/components/shared/ConsentModal';
@@ -9,6 +10,7 @@ export function AdminLayout() {
   const { user, isAdmin, loading, logout, profile, needsConsent, acceptConsent } = useAuth();
   const { clinic } = useClinic();
   const location = useLocation();
+  const pendingCount = usePendingCount();
 
   if (loading) return <Spinner overlay />;
   if (!user)    return <Navigate to="/login" replace />;
@@ -37,14 +39,19 @@ export function AdminLayout() {
             </Link>
             <nav className="hidden sm:flex items-center gap-1 ml-2">
               <Link
-                to="/admin"
-                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                to={pendingCount > 0 ? '/admin?filter=pending' : '/admin'}
+                className={`relative px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
                   location.pathname === '/admin'
                     ? 'bg-white/10 text-cream'
                     : 'text-cream/60 hover:text-cream hover:bg-white/5'
                 }`}
               >
                 予約一覧
+                {pendingCount > 0 && (
+                  <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-amber-500 text-white text-[10px] font-bold px-1 animate-pulse">
+                    {pendingCount > 99 ? '99+' : pendingCount}
+                  </span>
+                )}
               </Link>
               <Link
                 to="/admin/settings"
@@ -61,6 +68,18 @@ export function AdminLayout() {
           <div className="flex items-center gap-3">
             <span className="hidden sm:inline text-sm text-cream/50 font-mono">
               {profile?.displayName || user.email}
+              {profile?.lastLoginAt && (() => {
+                const raw = profile.lastLoginAt as unknown;
+                const ms = raw && typeof raw === 'object' && 'seconds' in (raw as Record<string,unknown>)
+                  ? (raw as { seconds: number }).seconds * 1000
+                  : typeof raw === 'string' ? new Date(raw).getTime() : 0;
+                if (!ms) return null;
+                return (
+                  <span className="ml-2 text-[11px] text-cream/30">
+                    最終: {new Date(ms).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                );
+              })()}
             </span>
             <Button
               variant="ghost"

--- a/oas-spa/src/components/layout/PatientLayout.tsx
+++ b/oas-spa/src/components/layout/PatientLayout.tsx
@@ -44,7 +44,7 @@ export function PatientLayout() {
           <div className="max-w-3xl mx-auto w-full px-4 pt-6 animate-slide-down">
             <div className={`flex items-start gap-3 px-4 py-3 rounded-lg border ${cfg.bg} ${cfg.border} ${cfg.text}`}>
               {cfg.icon}
-              <p className="text-sm leading-relaxed">{clinic.announcement.message}</p>
+              <p className="text-sm leading-relaxed whitespace-pre-line">{clinic.announcement.message}</p>
             </div>
           </div>
         );

--- a/oas-spa/src/components/shared/SortableHeader.tsx
+++ b/oas-spa/src/components/shared/SortableHeader.tsx
@@ -1,0 +1,94 @@
+import { cn } from '@/utils/cn';
+
+export type SortDir = 'asc' | 'desc';
+export interface SortKey {
+  col: string;
+  dir: SortDir;
+}
+
+interface SortableHeaderProps {
+  label: string;
+  sortKey: string;
+  sortKeys: SortKey[];
+  onSort: (key: string) => void;
+  className?: string;
+}
+
+export function SortableHeader({ label, sortKey, sortKeys, onSort, className }: SortableHeaderProps) {
+  const idx = sortKeys.findIndex(s => s.col === sortKey);
+  const isActive = idx >= 0;
+  const dir = isActive ? sortKeys[idx].dir : null;
+
+  return (
+    <th
+      className={cn(
+        'px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50 first:rounded-tl-lg last:rounded-tr-lg',
+        'cursor-pointer select-none hover:text-gold transition-colors',
+        isActive && 'text-gold',
+        className,
+      )}
+      onClick={() => onSort(sortKey)}
+    >
+      <span className="inline-flex items-center gap-0.5">
+        {label}
+        <span className="inline-flex items-center">
+          <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+            <path
+              d="M8 4l3 4H5l3-4z"
+              className={cn('transition-opacity', isActive && dir === 'asc' ? 'opacity-100' : 'opacity-20')}
+            />
+            <path
+              d="M8 12l3-4H5l3 4z"
+              className={cn('transition-opacity', isActive && dir === 'desc' ? 'opacity-100' : 'opacity-20')}
+            />
+          </svg>
+          {isActive && sortKeys.length > 1 && (
+            <sup className="text-[9px] font-bold text-gold -ml-0.5">{idx + 1}</sup>
+          )}
+        </span>
+      </span>
+    </th>
+  );
+}
+
+/** ソートキー切り替え: asc → desc → 除去 */
+export function toggleSortKey(sortKeys: SortKey[], col: string, maxKeys = 3): SortKey[] {
+  const idx = sortKeys.findIndex(s => s.col === col);
+  if (idx >= 0) {
+    const current = sortKeys[idx];
+    if (current.dir === 'asc') {
+      return sortKeys.map((s, i) => i === idx ? { ...s, dir: 'desc' as SortDir } : s);
+    } else {
+      return sortKeys.filter((_, i) => i !== idx);
+    }
+  } else {
+    const next = [...sortKeys, { col, dir: 'asc' as SortDir }];
+    return next.length > maxKeys ? next.slice(1) : next;
+  }
+}
+
+/** 複数カラムソート実行 */
+export function multiSort<T>(
+  items: T[],
+  sortKeys: SortKey[],
+  getValue: (item: T, col: string) => string | number,
+): T[] {
+  if (sortKeys.length === 0) return items;
+
+  return [...items].sort((a, b) => {
+    for (const { col, dir } of sortKeys) {
+      const va = getValue(a, col);
+      const vb = getValue(b, col);
+      let cmp = 0;
+
+      if (typeof va === 'number' && typeof vb === 'number') {
+        cmp = va - vb;
+      } else {
+        cmp = String(va).localeCompare(String(vb), 'ja');
+      }
+
+      if (cmp !== 0) return dir === 'desc' ? -cmp : cmp;
+    }
+    return 0;
+  });
+}

--- a/oas-spa/src/components/ui/Modal.tsx
+++ b/oas-spa/src/components/ui/Modal.tsx
@@ -35,14 +35,14 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
           aria-label={title}
           onClick={e => e.stopPropagation()}
           className={cn(
-            'relative bg-white rounded-xl shadow-xl',
-            'w-full max-w-md animate-scale-in',
+            'relative bg-white rounded-xl shadow-xl flex flex-col',
+            'w-full max-w-md max-h-[85vh] animate-scale-in',
             'border border-cream-300/60',
             className,
           )}
         >
           {title && (
-            <div className="flex items-center justify-between px-5 py-4 border-b border-cream-300/60">
+            <div className="flex items-center justify-between px-5 py-4 border-b border-cream-300/60 shrink-0">
               <h3 className="text-lg font-heading font-semibold text-navy-700">
                 {title}
               </h3>
@@ -58,7 +58,7 @@ export function Modal({ open, onClose, title, children, className }: ModalProps)
               </button>
             </div>
           )}
-          <div className="px-5 py-4">{children}</div>
+          <div className="px-5 py-4 overflow-y-auto min-h-0">{children}</div>
         </div>
       </div>
     </div>,

--- a/oas-spa/src/hooks/useAdmin.ts
+++ b/oas-spa/src/hooks/useAdmin.ts
@@ -48,12 +48,12 @@ export async function updateReservationStatus(
   cancelReason?: string,
 ): Promise<void> {
   if (newStatus === 'cancelled') {
-    // CF経由: audit_log + 患者キャンセル通知メール + スロット開放
+    // CF経由: audit_log + キャンセル通知メール + スロット開放
+    // [SEC-CR1] cancelledBy はサーバー側でIDトークンから判定（callFunctionが自動付与）
     await callFunction('cancelReservation', {
       reservationId: booking.id,
       phone: booking.phone,
       cancelReason: cancelReason || '',
-      cancelledBy: 'admin',
     });
     return;
   }

--- a/oas-spa/src/hooks/useAdmin.ts
+++ b/oas-spa/src/hooks/useAdmin.ts
@@ -1,9 +1,18 @@
 import { useState, useEffect, useCallback } from 'react';
-import { collection, onSnapshot, doc, writeBatch, addDoc } from 'firebase/firestore';
-import { db } from '@/lib/firebase';
-import { auth } from '@/lib/firebase';
+import { collection, onSnapshot, doc, writeBatch, addDoc, query, where } from 'firebase/firestore';
+import { db, auth } from '@/lib/firebase';
 import { callFunction } from '@/lib/functions';
 import type { ReservationRecord, ReservationStatus } from '@/types/reservation';
+
+/** 未確認予約件数リアルタイムリスナー（ヘッダーバッジ用） */
+export function usePendingCount() {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    const q = query(collection(db, 'reservations'), where('status', '==', 'pending'));
+    return onSnapshot(q, snap => setCount(snap.size), () => {});
+  }, []);
+  return count;
+}
 
 /** 予約リアルタイムリスナー */
 export function useReservations() {
@@ -32,20 +41,25 @@ export function useReservations() {
   return { reservations, loading };
 }
 
-/** 予約ステータス更新 */
+/** 予約ステータス更新（キャンセルはCF経由で通知メール送信） */
 export async function updateReservationStatus(
   booking: ReservationRecord,
   newStatus: ReservationStatus,
+  cancelReason?: string,
 ): Promise<void> {
-  const batch = writeBatch(db);
-  batch.update(doc(db, 'reservations', booking.id), { status: newStatus });
-
-  // キャンセル時はスロットも更新
-  if (newStatus === 'cancelled' && booking.date && booking.time) {
-    const slotId = `${booking.date}_${booking.time.replace(':', '')}`;
-    batch.update(doc(db, 'slots', slotId), { status: 'cancelled' });
+  if (newStatus === 'cancelled') {
+    // CF経由: audit_log + 患者キャンセル通知メール + スロット開放
+    await callFunction('cancelReservation', {
+      reservationId: booking.id,
+      phone: booking.phone,
+      cancelReason: cancelReason || '',
+      cancelledBy: 'admin',
+    });
+    return;
   }
 
+  const batch = writeBatch(db);
+  batch.update(doc(db, 'reservations', booking.id), { status: newStatus });
   await batch.commit();
 }
 
@@ -104,6 +118,8 @@ export async function deleteAdminUser(uid: string): Promise<void> {
 }
 
 /** CSV エクスポート（監査ログ付き） */
+const STATUS_JA: Record<string, string> = { pending: '未確認', confirmed: '確認済み', cancelled: 'キャンセル' };
+
 export function exportReservationsCsv(reservations: ReservationRecord[]): void {
   const headers = ['予約番号', '予約日', '予約時間', '氏名', 'ふりがな', '生年月日', '住所', '電話番号', 'メール', '性別', '初診/再診', '保険証', '症状', '伝達事項', '連絡方法', 'ステータス', '登録日時'];
 
@@ -113,7 +129,7 @@ export function exportReservationsCsv(reservations: ReservationRecord[]): void {
     r.id, r.date, r.time, r.name, r.furigana, r.birthdate,
     r.address, r.phone, r.email, r.gender,
     r.visitType, r.insurance, r.symptoms, r.notes,
-    r.contactMethod, r.status, r.createdAt,
+    r.contactMethod, STATUS_JA[r.status] || r.status, r.createdAt,
   ].map(escape).join(','));
 
   const csv = '\uFEFF' + [headers.join(','), ...rows].join('\r\n');

--- a/oas-spa/src/pages/Cancel.tsx
+++ b/oas-spa/src/pages/Cancel.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react';
-import { useLocation, useNavigate, Link } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { useClinic } from '@/hooks/useClinic';
 import { useToast } from '@/hooks/useToast';
 import { callFunction } from '@/lib/functions';
@@ -12,6 +12,9 @@ import { toHankaku } from '@/utils/security';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import type { ReservationRecord } from '@/types/reservation';
 
+/** 患者キャンセル理由の選択肢（健康関連を除外 — 要配慮個人情報に該当し得るため） */
+const CANCEL_REASONS = ['都合がつかなくなった', '日程を変更したい', 'その他'] as const;
+
 type Phase = 'search' | 'detail' | 'done';
 
 export default function Cancel() {
@@ -19,7 +22,9 @@ export default function Cancel() {
   const { showToast } = useToast();
   const location = useLocation();
   const navigate = useNavigate();
-  const passedBookingId = (location.state as { bookingId?: string } | null)?.bookingId ?? '';
+  const [searchParams] = useSearchParams();
+  // メール内リンク ?id=XXX または Complete画面からの state 経由
+  const passedBookingId = searchParams.get('id') || (location.state as { bookingId?: string } | null)?.bookingId || '';
   const [phase, setPhase] = useState<Phase>('search');
   const [reservationId, setReservationId] = useState(passedBookingId);
   const [phone, setPhone] = useState('');
@@ -28,6 +33,8 @@ export default function Cancel() {
   const [error, setError] = useState('');
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [cancelling, setCancelling] = useState(false);
+  const [cancelReason, setCancelReason] = useState('');
+  const [cancelReasonOther, setCancelReasonOther] = useState('');
 
   /** キャンセル可能期限 */
   const cutoffMinutes = clinic?.cancelCutoffMinutes ?? 60;
@@ -77,6 +84,8 @@ export default function Cancel() {
       await callFunction('cancelReservation', {
         reservationId: reservationId.trim(),
         phone: toHankaku(phone.trim()),
+        cancelReason: cancelReason === 'その他' ? (cancelReasonOther || 'その他') : (cancelReason || ''),
+        cancelledBy: 'patient',
       });
       setPhase('done');
     } catch (err: unknown) {
@@ -200,12 +209,34 @@ export default function Cancel() {
                 キャンセル受付期限: {deadline} まで
               </span>
             </Alert>
-            <Button variant="danger" className="w-full" onClick={() => setConfirmOpen(true)} loading={cancelling}>
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-              この予約をキャンセルする
-            </Button>
+            <Card>
+              <CardBody className="space-y-3">
+                <label className="block text-sm font-medium text-navy-600">キャンセル理由（任意）</label>
+                <select
+                  value={cancelReason}
+                  onChange={e => { setCancelReason(e.target.value); if (e.target.value !== 'その他') setCancelReasonOther(''); }}
+                  className="w-full rounded-lg border border-cream-300 bg-white px-3 py-2 text-sm text-navy-700 focus:outline-none focus:ring-2 focus:ring-gold/30 focus:border-gold"
+                >
+                  <option value="">選択しない</option>
+                  {CANCEL_REASONS.map(r => <option key={r} value={r}>{r}</option>)}
+                </select>
+                {cancelReason === 'その他' && (
+                  <input
+                    type="text"
+                    value={cancelReasonOther}
+                    onChange={e => setCancelReasonOther(e.target.value)}
+                    placeholder="理由を入力してください"
+                    className="w-full rounded-lg border border-cream-300 bg-white px-3 py-2 text-sm text-navy-700 focus:outline-none focus:ring-2 focus:ring-gold/30 focus:border-gold"
+                  />
+                )}
+                <Button variant="danger" className="w-full" onClick={() => setConfirmOpen(true)} loading={cancelling}>
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                  この予約をキャンセルする
+                </Button>
+              </CardBody>
+            </Card>
           </>
         )}
 

--- a/oas-spa/src/pages/Cancel.tsx
+++ b/oas-spa/src/pages/Cancel.tsx
@@ -81,11 +81,11 @@ export default function Cancel() {
     setConfirmOpen(false);
     setCancelling(true);
     try {
+      // [SEC-CR1] cancelledBy はサーバー側でIDトークン有無から判定
       await callFunction('cancelReservation', {
         reservationId: reservationId.trim(),
         phone: toHankaku(phone.trim()),
         cancelReason: cancelReason === 'その他' ? (cancelReasonOther || 'その他') : (cancelReason || ''),
-        cancelledBy: 'patient',
       });
       setPhase('done');
     } catch (err: unknown) {

--- a/oas-spa/src/pages/admin/Dashboard.tsx
+++ b/oas-spa/src/pages/admin/Dashboard.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useReservations, useKpis, updateReservationStatus, exportReservationsCsv } from '@/hooks/useAdmin';
 import { useToast } from '@/hooks/useToast';
 import { Card, CardBody } from '@/components/ui/Card';
@@ -9,6 +10,7 @@ import { Modal } from '@/components/ui/Modal';
 import { Spinner } from '@/components/ui/Spinner';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
+import { SortableHeader, toggleSortKey, multiSort, type SortKey } from '@/components/shared/SortableHeader';
 import { formatDateTimeJa, calcAge } from '@/utils/date';
 import { cn } from '@/utils/cn';
 import type { ReservationRecord, ReservationStatus } from '@/types/reservation';
@@ -28,10 +30,24 @@ const KPI_ICONS = [
 
 type KpiFilter = 'today' | 'month' | 'new' | 'pending' | null;
 
+/** ソート用の値取得 */
+function getReservationValue(r: ReservationRecord, col: string): string | number {
+  switch (col) {
+    case 'datetime':   return `${r.date} ${r.time}`;
+    case 'name':       return r.furigana || r.name;
+    case 'visitType':  return r.visitType || '';
+    case 'phone':      return r.phone;
+    case 'createdAt':  return r.createdAt || '';
+    case 'status':     return r.status;
+    default:           return '';
+  }
+}
+
 export default function Dashboard() {
   const { reservations, loading } = useReservations();
   const kpis = useKpis(reservations);
   const { showToast } = useToast();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   // フィルター
   const [statusFilter, setStatusFilter] = useState<ReservationStatus | 'all'>('all');
@@ -42,6 +58,16 @@ export default function Dashboard() {
   const [createdAtFilter, setCreatedAtFilter] = useState('');
   const [kpiFilter, setKpiFilter] = useState<KpiFilter>(null);
 
+  // URLパラメータ ?filter=pending 経由のフィルター適用（バッジクリック対応）
+  useEffect(() => {
+    const f = searchParams.get('filter') as ReservationStatus | null;
+    if (f) {
+      setStatusFilter(f);
+      setKpiFilter(f as KpiFilter);
+      setSearchParams({}, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
+
   // 詳細モーダル
   const [selected, setSelected] = useState<ReservationRecord | null>(null);
   // 症状モーダル
@@ -50,6 +76,12 @@ export default function Dashboard() {
   // ステータス変更確認
   const [confirmAction, setConfirmAction] = useState<{ booking: ReservationRecord; status: ReservationStatus } | null>(null);
   const [updating, setUpdating] = useState(false);
+  const [cancelReason, setCancelReason] = useState('');
+  const [cancelReasonOther, setCancelReasonOther] = useState('');
+
+  // ソート
+  const [sortKeys, setSortKeys] = useState<SortKey[]>([{ col: 'datetime', dir: 'desc' }]);
+  function handleSort(key: string) { setSortKeys(prev => toggleSortKey(prev, key)); }
 
   const todayStr = useMemo(() => {
     const d = new Date();
@@ -113,6 +145,8 @@ export default function Dashboard() {
     return list;
   }, [reservations, statusFilter, dateFilter, search, phoneSearch, zipSearch, createdAtFilter, kpiFilter, todayStr, monthPrefix]);
 
+  const sorted = useMemo(() => multiSort(filtered, sortKeys, getReservationValue), [filtered, sortKeys]);
+
   /** 通常フィルター操作時はKPIフィルターをクリア */
   function setStatusFilterAndClearKpi(s: ReservationStatus | 'all') {
     setKpiFilter(null);
@@ -134,16 +168,26 @@ export default function Dashboard() {
   /** ステータス更新 */
   async function handleStatusUpdate() {
     if (!confirmAction) return;
+    const isCancelling = confirmAction.status === 'cancelled';
+    const reason = isCancelling
+      ? (cancelReason === 'その他' ? cancelReasonOther.trim() : cancelReason)
+      : undefined;
+    if (isCancelling && !reason) {
+      showToast('キャンセル理由を選択してください', 'error');
+      return;
+    }
     setUpdating(true);
     try {
-      await updateReservationStatus(confirmAction.booking, confirmAction.status);
-      showToast('ステータスを更新しました', 'success');
+      await updateReservationStatus(confirmAction.booking, confirmAction.status, reason);
+      showToast(isCancelling ? 'キャンセルしました（患者に通知メール送信済み）' : 'ステータスを更新しました', 'success');
       setSelected(null);
     } catch {
       showToast('更新に失敗しました', 'error');
     } finally {
       setUpdating(false);
       setConfirmAction(null);
+      setCancelReason('');
+      setCancelReasonOther('');
     }
   }
 
@@ -198,7 +242,7 @@ export default function Dashboard() {
                 </Button>
               ))}
             </div>
-            <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(filtered)}>
+            <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(sorted)}>
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
               </svg>
@@ -249,7 +293,7 @@ export default function Dashboard() {
       {/* 予約テーブル */}
       <Card>
         <div className="overflow-x-auto">
-          {filtered.length === 0 ? (
+          {sorted.length === 0 ? (
             <EmptyState
               icon={
                 <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -263,13 +307,18 @@ export default function Dashboard() {
             <table className="w-full text-sm border-separate border-spacing-0">
               <thead>
                 <tr className="border-b border-cream-200">
-                  {['診察予定日時', '氏名', '初/再', '症状', '電話', '予約受付日', 'ステータス', ''].map(h => (
-                    <th key={h} className="px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50 first:rounded-tl-lg last:rounded-tr-lg">{h}</th>
-                  ))}
+                  <SortableHeader label="診察予定日時" sortKey="datetime" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label="氏名" sortKey="name" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label="初/再" sortKey="visitType" sortKeys={sortKeys} onSort={handleSort} />
+                  <th className="px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50">症状</th>
+                  <SortableHeader label="電話" sortKey="phone" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label="予約受付日" sortKey="createdAt" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label="ステータス" sortKey="status" sortKeys={sortKeys} onSort={handleSort} />
+                  <th className="px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50 last:rounded-tr-lg" />
                 </tr>
               </thead>
               <tbody>
-                {filtered.map(r => (
+                {sorted.map(r => (
                   <tr key={r.id} className="border-b border-cream-100 hover:bg-cream-100/60 transition-colors">
                     <td className="px-3 py-3 whitespace-nowrap font-mono text-navy-700 text-xs">
                       {formatDateTimeJa(r.date, r.time)}
@@ -303,6 +352,11 @@ export default function Dashboard() {
                     </td>
                     <td className="px-3 py-3 whitespace-nowrap">
                       <Badge className={STATUS_BADGE[r.status].cls}>{STATUS_BADGE[r.status].label}</Badge>
+                      {r.status === 'cancelled' && r.cancelledBy && (
+                        <span className="ml-1 text-[10px] text-navy-400">
+                          ({r.cancelledBy === 'admin' ? '管理者' : '患者'})
+                        </span>
+                      )}
                     </td>
                     <td className="px-3 py-3 whitespace-nowrap">
                       <Button size="sm" variant="ghost" onClick={() => setSelected(r)}>
@@ -324,33 +378,40 @@ export default function Dashboard() {
       {/* 詳細モーダル */}
       {selected && (
         <Modal open={!!selected} onClose={() => setSelected(null)} title="予約詳細" className="max-w-lg">
-          <dl className="space-y-1 text-sm mb-6">
-            {[
-              ['予約番号', selected.id],
-              ['診察予定日時', formatDateTimeJa(selected.date, selected.time)],
-              ['氏名', selected.name],
-              ['ふりがな', selected.furigana],
-              ['生年月日', selected.birthdate + (calcAge(selected.birthdate) !== null ? `（${calcAge(selected.birthdate)}歳）` : '')],
-              ['郵便番号', selected.zip || '-'],
-              ['住所', selected.address],
-              ['電話番号', selected.phone],
-              ['メール', selected.email || '-'],
-              ['性別', selected.gender || '未入力'],
-              ['初診/再診', selected.visitType || '-'],
-              ['保険証', selected.insurance || '-'],
-              ['症状', selected.symptoms],
-              ['伝達事項', selected.notes || 'なし'],
-              ['連絡方法', selected.contactMethod || '-'],
-              ['ステータス', STATUS_BADGE[selected.status].label],
-              ['予約受付日', selected.createdAt ? new Date(selected.createdAt).toLocaleString('ja-JP') : '-'],
-            ].map(([label, val]) => (
-              <div key={label} className="flex border-b border-cream-200/80 py-2">
-                <dt className="w-24 shrink-0 text-navy-400">{label}</dt>
-                <dd className="text-navy-700 whitespace-pre-wrap break-all">{val}</dd>
-              </div>
-            ))}
-          </dl>
-          <div className="flex gap-2 justify-end">
+          <div className="overflow-y-auto -mx-5 px-5" style={{ maxHeight: 'calc(85vh - 10rem)' }}>
+            <dl className="space-y-1 text-sm">
+              {[
+                ['予約番号', selected.id],
+                ['診察予定日時', formatDateTimeJa(selected.date, selected.time)],
+                ['氏名', selected.name],
+                ['ふりがな', selected.furigana],
+                ['生年月日', selected.birthdate + (calcAge(selected.birthdate) !== null ? `（${calcAge(selected.birthdate)}歳）` : '')],
+                ['郵便番号', selected.zip || '-'],
+                ['住所', selected.address],
+                ['電話番号', selected.phone],
+                ['メール', selected.email || '-'],
+                ['性別', selected.gender || '未入力'],
+                ['初診/再診', selected.visitType || '-'],
+                ['保険証', selected.insurance || '-'],
+                ['症状', selected.symptoms],
+                ['伝達事項', selected.notes || 'なし'],
+                ['連絡方法', selected.contactMethod || '-'],
+                ['ステータス', STATUS_BADGE[selected.status].label],
+                ...(selected.status === 'cancelled' ? [
+                  ['キャンセル元', selected.cancelledBy === 'admin' ? '管理者' : selected.cancelledBy === 'patient' ? '患者' : '-'],
+                  ['キャンセル理由', selected.cancelReason || '-'],
+                  ['キャンセル日時', selected.cancelledAt ? new Date(selected.cancelledAt).toLocaleString('ja-JP') : '-'],
+                ] : []),
+                ['予約受付日', selected.createdAt ? new Date(selected.createdAt).toLocaleString('ja-JP') : '-'],
+              ].map(([label, val]) => (
+                <div key={label} className="flex border-b border-cream-200/80 py-2">
+                  <dt className="w-24 shrink-0 text-navy-400">{label}</dt>
+                  <dd className="text-navy-700 whitespace-pre-wrap break-all">{val}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+          <div className="flex gap-2 justify-end pt-4 border-t border-cream-200/60 mt-4 shrink-0">
             <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
               閉じる
             </Button>
@@ -387,18 +448,62 @@ export default function Dashboard() {
         </Modal>
       )}
 
-      {/* ステータス変更確認 */}
+      {/* ステータス変更確認（確認済み） */}
       <ConfirmDialog
-        open={!!confirmAction}
+        open={!!confirmAction && confirmAction.status !== 'cancelled'}
         title="ステータス変更"
-        message={confirmAction?.status === 'cancelled'
-          ? `${confirmAction.booking.name}様の予約をキャンセルしますか？`
-          : `${confirmAction?.booking.name}様の予約を確認済みにしますか？`}
-        okLabel={confirmAction?.status === 'cancelled' ? 'キャンセルする' : '確認済みにする'}
-        variant={confirmAction?.status === 'cancelled' ? 'danger' : 'primary'}
+        message={`${confirmAction?.booking.name}様の予約を確認済みにしますか？`}
+        okLabel="確認済みにする"
+        variant="primary"
         onConfirm={handleStatusUpdate}
         onCancel={() => setConfirmAction(null)}
       />
+
+      {/* キャンセル確認（理由必須） */}
+      {confirmAction?.status === 'cancelled' && (
+        <Modal open onClose={() => { setConfirmAction(null); setCancelReason(''); setCancelReasonOther(''); }} title="予約キャンセル">
+          <p className="text-sm text-navy-500 mb-4">
+            {confirmAction.booking.name}様の予約をキャンセルします。<br />
+            患者にキャンセル通知メールが送信されます。
+          </p>
+          <label className="block text-sm font-medium text-navy-600 mb-1">キャンセル理由（必須）</label>
+          <select
+            value={cancelReason}
+            onChange={e => { setCancelReason(e.target.value); if (e.target.value !== 'その他') setCancelReasonOther(''); }}
+            className="w-full rounded-lg border border-cream-300 bg-white px-3 py-2 text-sm text-navy-700 focus:outline-none focus:ring-2 focus:ring-gold/30 focus:border-gold mb-3"
+          >
+            <option value="">選択してください</option>
+            <option value="医師都合による休診">医師都合による休診</option>
+            <option value="臨時休診">臨時休診</option>
+            <option value="患者様からの電話依頼">患者様からの電話依頼</option>
+            <option value="予約重複の整理">予約重複の整理</option>
+            <option value="その他">その他</option>
+          </select>
+          {cancelReason === 'その他' && (
+            <input
+              type="text"
+              value={cancelReasonOther}
+              onChange={e => setCancelReasonOther(e.target.value)}
+              placeholder="理由を入力してください"
+              maxLength={200}
+              className="w-full rounded-lg border border-cream-300 bg-white px-3 py-2 text-sm text-navy-700 focus:outline-none focus:ring-2 focus:ring-gold/30 focus:border-gold mb-3"
+            />
+          )}
+          <div className="flex justify-end gap-3 mt-4">
+            <Button variant="ghost" onClick={() => { setConfirmAction(null); setCancelReason(''); setCancelReasonOther(''); }}>
+              戻る
+            </Button>
+            <Button
+              variant="danger"
+              loading={updating}
+              disabled={!cancelReason || (cancelReason === 'その他' && !cancelReasonOther.trim())}
+              onClick={handleStatusUpdate}
+            >
+              キャンセルする
+            </Button>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/oas-spa/src/pages/admin/Settings.tsx
+++ b/oas-spa/src/pages/admin/Settings.tsx
@@ -779,8 +779,73 @@ function TermsTab({ form, update }: { form: Partial<ClinicSettings>; update: (p:
 
 /* ── ポリシータブ（PP + 要配慮個人情報同意文言） ── */
 function PolicyTab({ form, update }: { form: Partial<ClinicSettings>; update: (p: Partial<ClinicSettings>) => void }) {
+  const name = form.clinicName || '〇〇クリニック';
+  const phone = form.phone || '000-0000-0000';
+
+  const [confirmRegenerate, setConfirmRegenerate] = useState(false);
+
+  /** テンプレートテキストを生成 */
+  function generateTexts() {
+    return {
+      privacyPolicy: `プライバシーポリシー\n\n${name}（以下「当院」）は、患者様の個人情報の保護に努め、個人情報の保護に関する法律（個人情報保護法）を遵守いたします。\n\n【収集する情報】\nお名前、ふりがな、生年月日、住所、電話番号、メールアドレス、症状・お悩み（要配慮個人情報）、保険証情報\n\n【利用目的】\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n【第三者提供】\nご本人の同意なく、個人情報を第三者に提供することはありません。ただし、法令に基づく場合を除きます。\n\n【要配慮個人情報の取り扱い】\n症状・お悩み等の健康に関する情報は「要配慮個人情報」として、ご本人の明示的な同意を得た上で取得・利用いたします。\n\n【データの保存期間】\nお預かりした個人情報は、利用目的の達成後、当院が定める保存期間を経て安全に削除いたします。\n\n【開示・訂正・利用停止】\nご自身の個人情報の開示・訂正・利用停止をご希望の場合は、下記の窓口までご連絡ください。本人確認の上、法令に基づき対応いたします。\n\n【お問い合わせ窓口】\n${name} 個人情報相談窓口\n電話: ${phone}`,
+      sensitiveDataConsentText: `「症状・お悩み」欄に入力される健康に関する情報は、個人情報保護法上の「要配慮個人情報」に該当する可能性があります。${name}の予約対応・施術準備の目的でのみ使用し、ご本人の同意なく第三者に提供することはありません。`,
+      dataRetentionPurpose: `${name}は、ご予約時にご提供いただく個人情報を、以下の目的で利用いたします。\n\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n上記目的の達成後、所定の保存期間を経て安全に削除いたします。`,
+      patientRightsContact: `個人情報の開示・訂正・利用停止をご希望の場合は、下記までご連絡ください。\n\n窓口: ${name} 個人情報相談窓口\n電話: ${phone}\n\n本人確認の上、法令に基づき対応いたします。`,
+    };
+  }
+
+  /** 未入力フィールドのみ自動生成 */
+  function autoFillDefaults() {
+    const texts = generateTexts();
+    const patch: Partial<ClinicSettings> = {};
+    if (!form.privacyPolicy?.trim()) patch.privacyPolicy = texts.privacyPolicy;
+    if (!form.sensitiveDataConsentText?.trim()) patch.sensitiveDataConsentText = texts.sensitiveDataConsentText;
+    if (!form.dataRetentionPurpose?.trim()) patch.dataRetentionPurpose = texts.dataRetentionPurpose;
+    if (!form.patientRightsContact?.trim()) patch.patientRightsContact = texts.patientRightsContact;
+    if (Object.keys(patch).length > 0) update(patch);
+  }
+
+  /** 全フィールドを上書き再生成 */
+  function regenerateAll() {
+    update(generateTexts());
+    setConfirmRegenerate(false);
+  }
+
+  const hasEmpty = !form.privacyPolicy?.trim() || !form.sensitiveDataConsentText?.trim() || !form.dataRetentionPurpose?.trim() || !form.patientRightsContact?.trim();
+
   return (
     <div className="space-y-4">
+      {hasEmpty ? (
+        <Alert variant="info">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm">未入力のポリシー項目があります。基本情報（院名・電話番号）から自動生成できます。</span>
+            <Button size="sm" variant="secondary" onClick={autoFillDefaults} className="shrink-0">
+              自動生成
+            </Button>
+          </div>
+        </Alert>
+      ) : (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setConfirmRegenerate(true)}
+            className="text-xs text-navy-400 hover:text-navy-600 underline underline-offset-2 transition-colors"
+          >
+            基本情報から再生成
+          </button>
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmRegenerate}
+        title="ポリシーテキストを再生成"
+        message="すべてのポリシーテキストを基本情報（院名・電話番号）から再生成します。手動で編集した内容は上書きされます。"
+        okLabel="再生成する"
+        cancelLabel="キャンセル"
+        onConfirm={regenerateAll}
+        onCancel={() => setConfirmRegenerate(false)}
+      />
+
       <Card>
         <CardHeader>
           <h3 className="text-sm font-medium text-navy-700">プライバシーポリシー</h3>
@@ -790,11 +855,11 @@ function PolicyTab({ form, update }: { form: Partial<ClinicSettings>; update: (p
             label="プライバシーポリシーテキスト"
             value={form.privacyPolicy || ''}
             onChange={e => update({ privacyPolicy: e.target.value })}
-            rows={8}
-            placeholder="患者に表示するプライバシーポリシーを入力してください"
+            rows={12}
+            placeholder={'プライバシーポリシー\n\n〇〇クリニック（以下「当院」）は、患者様の個人情報の保護に努め、個人情報の保護に関する法律（個人情報保護法）を遵守いたします。\n\n【収集する情報】\nお名前、ふりがな、生年月日、住所、電話番号、メールアドレス、症状・お悩み（要配慮個人情報）、保険証情報\n\n【利用目的】\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n【第三者提供】\nご本人の同意なく、個人情報を第三者に提供することはありません。ただし、法令に基づく場合を除きます。\n\n【要配慮個人情報の取り扱い】\n症状・お悩み等の健康に関する情報は「要配慮個人情報」として、ご本人の明示的な同意を得た上で取得・利用いたします。\n\n【データの保存期間】\nお預かりした個人情報は、利用目的の達成後、当院が定める保存期間を経て安全に削除いたします。\n\n【開示・訂正・利用停止】\nご自身の個人情報の開示・訂正・利用停止をご希望の場合は、下記の窓口までご連絡ください。本人確認の上、法令に基づき対応いたします。\n\n【お問い合わせ窓口】\n〇〇クリニック 個人情報相談窓口\n電話: 000-0000-0000\nメール: privacy@example.com'}
           />
           <p className="text-[11px] text-navy-400">
-            予約フォームの個人情報同意チェックボックスからリンクされます。
+            予約フォームの個人情報同意チェックボックスからリンクされます。空欄の場合はプレースホルダーの内容が使用されます。
           </p>
         </CardBody>
       </Card>
@@ -844,7 +909,7 @@ function PolicyTab({ form, update }: { form: Partial<ClinicSettings>; update: (p
             value={form.dataRetentionPurpose || ''}
             onChange={e => update({ dataRetentionPurpose: e.target.value })}
             rows={5}
-            placeholder={'当院は、ご予約時にご提供いただく個人情報を、以下の目的で利用いたします。\n\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n\n上記目的の達成後、所定の保存期間を経て安全に削除いたします。'}
+            placeholder={'当院は、ご予約時にご提供いただく個人情報を、以下の目的で利用いたします。\n\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n上記目的の達成後、所定の保存期間を経て安全に削除いたします。'}
           />
           <p className="text-[11px] text-navy-400">
             プライバシーポリシーおよび予約フォームに表示されます。空欄の場合はプレースホルダーの内容が使用されます。

--- a/oas-spa/src/types/reservation.ts
+++ b/oas-spa/src/types/reservation.ts
@@ -38,6 +38,10 @@ export interface ReservationRecord {
   hasSensitiveDataConsent: boolean;
   /** [H2] リマインダーメール配信同意 */
   reminderEmailConsent: boolean;
+  /** キャンセル情報 */
+  cancelledBy?: 'admin' | 'patient';
+  cancelReason?: string;
+  cancelledAt?: string;
   /** メタデータ */
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- **キャンセルフロー改修**: 管理者（理由必須）・患者（理由任意）双方からのキャンセル + メール通知 + 監査ログ（cancelledBy/cancelReason/cancelledAt）
- **予約一覧ソート**: AMS SortableHeader移植、複数カラムソート対応、未確認バッジ＋フィルタ連携
- **UI/UX**: モーダルスクロール＋フッター固定、最終ログイン表示、バナー改行対応、ポリシー再生成機能

## Test plan
- [ ] 管理者キャンセル: 理由選択 → 患者にメール届く
- [ ] 患者キャンセル: メールリンクから /cancel?id=XXX → キャンセル成功 → 管理者にメール届く
- [ ] 患者キャンセル「その他」で自由記述入力ボックス表示
- [ ] 予約一覧: カラムヘッダークリックでソート（asc→desc→除去）
- [ ] 未確認バッジクリック → 一覧がpendingでフィルタ
- [ ] 詳細モーダル: 長い内容でスクロール、フッターボタン固定
- [ ] キャンセル済み予約にキャンセル元・理由・日時表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)