### PR TITLE
[OAS-UX] 管理者ヘッダーに言語切り替えアイコン追加

### DIFF
--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -6,6 +6,7 @@ import { usePendingCount } from '@/hooks/useAdmin';
 import { Spinner } from '@/components/ui/Spinner';
 import { Button } from '@/components/ui/Button';
 import { ConsentModal } from '@/components/shared/ConsentModal';
+import { LanguageSwitcher } from '@/components/shared/LanguageSwitcher';
 
 export function AdminLayout() {
   const { t } = useTranslation('admin');
@@ -94,6 +95,7 @@ export function AdminLayout() {
                 );
               })()}
             </span>
+            <LanguageSwitcher variant="header" />
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
## Summary

- `AdminLayout.tsx` に `LanguageSwitcher` を追加
- ロゴアウトボタンの左隣に地球儀アイコンを配置
- 管理者も患者側と同様に7言語（ja/en/zh-CN/vi/ko/pt-BR/tl）を切り替え可能に

## Test plan
- [ ] 管理者ヘッダーに地球儀アイコンが表示されること
- [ ] クリックすると言語選択ドロップダウンが表示され、切り替えが機能すること
- [ ] ダークネイビー背景のヘッダー上でスタイルが崩れないこと（`variant="header"` 指定）

🤖 Generated with [Claude Code](https://claude.ai/code)