### PR TITLE
[OAS] CSV出力を多言語対応（7言語）

### DIFF
--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -6,6 +6,7 @@ import { usePendingCount } from '@/hooks/useAdmin';
 import { Spinner } from '@/components/ui/Spinner';
 import { Button } from '@/components/ui/Button';
 import { ConsentModal } from '@/components/shared/ConsentModal';
+import { LanguageSwitcher } from '@/components/shared/LanguageSwitcher';
 
 export function AdminLayout() {
   const { t } = useTranslation('admin');
@@ -94,6 +95,7 @@ export function AdminLayout() {
                 );
               })()}
             </span>
+            <LanguageSwitcher variant="header" />
             <Button
               variant="ghost"
               size="sm"

--- a/oas-spa/src/hooks/useAdmin.ts
+++ b/oas-spa/src/hooks/useAdmin.ts
@@ -118,26 +118,25 @@ export async function deleteAdminUser(uid: string): Promise<void> {
 }
 
 /** CSV エクスポート（監査ログ付き） */
-const STATUS_JA: Record<string, string> = { pending: '未確認', confirmed: '確認済み', cancelled: 'キャンセル' };
-
-export function exportReservationsCsv(reservations: ReservationRecord[]): void {
-  const headers = ['予約番号', '予約日', '予約時間', '氏名', 'ふりがな', '生年月日', '住所', '電話番号', 'メール', '性別', '初診/再診', '保険証', '症状', '伝達事項', '連絡方法', 'ステータス', '登録日時'];
-
+export function exportReservationsCsv(
+  reservations: ReservationRecord[],
+  labels: { headers: string[]; statusLabels: Record<string, string>; filename: string },
+): void {
   const escape = (v: string) => `"${(v || '').replace(/"/g, '""')}"`;
 
   const rows = reservations.map(r => [
     r.id, r.date, r.time, r.name, r.furigana, r.birthdate,
     r.address, r.phone, r.email, r.gender,
     r.visitType, r.insurance, r.symptoms, r.notes,
-    r.contactMethod, STATUS_JA[r.status] || r.status, r.createdAt,
+    r.contactMethod, labels.statusLabels[r.status] || r.status, r.createdAt,
   ].map(escape).join(','));
 
-  const csv = '\uFEFF' + [headers.join(','), ...rows].join('\r\n');
+  const csv = '\uFEFF' + [labels.headers.join(','), ...rows].join('\r\n');
   const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `予約データ_${new Date().toISOString().slice(0, 10)}.csv`;
+  a.download = labels.filename;
   a.click();
   URL.revokeObjectURL(url);
 

--- a/oas-spa/src/i18n/locales/en/admin.json
+++ b/oas-spa/src/i18n/locales/en/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "Enter reason",
       "back": "Back",
       "confirm": "Cancel Reservation"
+    },
+    "csv": {
+      "date": "Date",
+      "time": "Time",
+      "filename": "reservations_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/ja/admin.json
+++ b/oas-spa/src/i18n/locales/ja/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "理由を入力してください",
       "back": "戻る",
       "confirm": "キャンセルする"
+    },
+    "csv": {
+      "date": "予約日",
+      "time": "予約時間",
+      "filename": "予約データ_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/ko/admin.json
+++ b/oas-spa/src/i18n/locales/ko/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "이유를 입력하세요",
       "back": "뒤로",
       "confirm": "취소 확인"
+    },
+    "csv": {
+      "date": "예약일",
+      "time": "예약시간",
+      "filename": "예약데이터_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/pt-BR/admin.json
+++ b/oas-spa/src/i18n/locales/pt-BR/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "Digite o motivo",
       "back": "Voltar",
       "confirm": "Confirmar Cancelamento"
+    },
+    "csv": {
+      "date": "Data",
+      "time": "Horário",
+      "filename": "reservas_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/tl/admin.json
+++ b/oas-spa/src/i18n/locales/tl/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "Ilagay ang dahilan",
       "back": "Bumalik",
       "confirm": "Kumpirmahin ang Pagkansela"
+    },
+    "csv": {
+      "date": "Petsa",
+      "time": "Oras",
+      "filename": "mga-reserbacyon_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/vi/admin.json
+++ b/oas-spa/src/i18n/locales/vi/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "Nhập lý do",
       "back": "Quay Lại",
       "confirm": "Xác Nhận Hủy"
+    },
+    "csv": {
+      "date": "Ngày",
+      "time": "Giờ",
+      "filename": "dat-lich_"
     }
   },
   "settings": {

--- a/oas-spa/src/i18n/locales/zh-CN/admin.json
+++ b/oas-spa/src/i18n/locales/zh-CN/admin.json
@@ -106,6 +106,11 @@
       "otherReasonPlaceholder": "请输入原因",
       "back": "返回",
       "confirm": "确认取消"
+    },
+    "csv": {
+      "date": "预约日",
+      "time": "预约时间",
+      "filename": "预约数据_"
     }
   },
   "settings": {

--- a/oas-spa/src/pages/admin/Dashboard.tsx
+++ b/oas-spa/src/pages/admin/Dashboard.tsx
@@ -195,6 +195,34 @@ export default function Dashboard() {
     }
   }
 
+  const csvLabels = {
+    headers: [
+      t('dashboard.modal.fields.reservationId'),
+      t('dashboard.csv.date'),
+      t('dashboard.csv.time'),
+      t('dashboard.modal.fields.name'),
+      t('dashboard.modal.fields.furigana'),
+      t('dashboard.modal.fields.birthdate'),
+      t('dashboard.modal.fields.address'),
+      t('dashboard.modal.fields.phone'),
+      t('dashboard.modal.fields.email'),
+      t('dashboard.modal.fields.gender'),
+      t('dashboard.modal.fields.visitType'),
+      t('dashboard.modal.fields.insurance'),
+      t('dashboard.modal.fields.symptoms'),
+      t('dashboard.modal.fields.notes'),
+      t('dashboard.modal.fields.contactMethod'),
+      t('dashboard.table.status'),
+      t('dashboard.modal.fields.createdAt'),
+    ],
+    statusLabels: {
+      pending:   t('dashboard.status.pending'),
+      confirmed: t('dashboard.status.confirmed'),
+      cancelled: t('dashboard.status.cancelled'),
+    },
+    filename: `${t('dashboard.csv.filename')}${new Date().toISOString().slice(0, 10)}.csv`,
+  };
+
   if (loading) return <Spinner className="py-12" />;
 
   return (
@@ -246,7 +274,7 @@ export default function Dashboard() {
                 </Button>
               ))}
             </div>
-            <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(sorted)}>
+            <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(sorted, csvLabels)}>
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
               </svg>


### PR DESCRIPTION
## Summary

- `exportReservationsCsv()` のシグネチャに `labels` パラメータを追加し、ヘッダー・ステータス文言・ファイル名をハードコードから排除
- `Dashboard.tsx` で `useTranslation('admin')` の `t()` を使って `csvLabels` を構築して渡す
- 既存の `dashboard.modal.fields.*` / `dashboard.status.*` / `dashboard.table.status` キーを最大限再利用
- 新規追加キー: `dashboard.csv.date` / `dashboard.csv.time` / `dashboard.csv.filename` を 7 言語に追加

## Test plan

- [ ] 日本語でCSV出力 → ヘッダーが日本語、ファイル名が `予約データ_YYYY-MM-DD.csv`
- [ ] 英語に切替後にCSV出力 → ヘッダーが英語、ファイル名が `reservations_YYYY-MM-DD.csv`
- [ ] ステータス列が表示中の言語に合わせて変わることを確認
- [ ] 全7言語（ja/en/zh-CN/vi/ko/pt-BR/tl）で JSON parse エラーがないことを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)