### PR TITLE
[OAS] 管理者代行予約ボタン + 代行入力モード

### DIFF
--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -66,6 +66,18 @@ export function AdminLayout() {
               >
                 {t('layout.settings')}
               </Link>
+              {/* 代行予約 — 新規タブで予約画面を開く */}
+              <a
+                href="/?admin=1"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 text-cream/60 hover:text-cream hover:bg-white/5 flex items-center gap-1"
+              >
+                <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                </svg>
+                {t('layout.proxyBooking')}
+              </a>
             </nav>
           </div>
           <div className="flex items-center gap-3">

--- a/oas-spa/src/hooks/useReservation.ts
+++ b/oas-spa/src/hooks/useReservation.ts
@@ -18,8 +18,9 @@ interface CreateResult {
 /** 予約を作成 */
 export async function createReservation(
   data: ReservationFormData,
+  inputBy?: 'admin',
 ): Promise<{ bookingId: string }> {
-  const payload = {
+  const payload: Record<string, unknown> = {
     date: data.date,
     time: data.time,
     name: data.name,
@@ -39,6 +40,7 @@ export async function createReservation(
     contactMethod: data.contactMethod,
     hasSensitiveDataConsent: data.hasSensitiveDataConsent,
   };
+  if (inputBy) payload.inputBy = inputBy;
   const result = await callFunction<CreateResult>('createReservation', payload);
   return { bookingId: result.reservationId };
 }

--- a/oas-spa/src/i18n/locales/en/admin.json
+++ b/oas-spa/src/i18n/locales/en/admin.json
@@ -5,7 +5,8 @@
     "settings": "Settings",
     "logout": "Logout",
     "lastLogin": "Last: ",
-    "consentPending": "ToS / Privacy Pending"
+    "consentPending": "ToS / Privacy Pending",
+    "proxyBooking": "Book for Patient"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/en/booking.json
+++ b/oas-spa/src/i18n/locales/en/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "Previous month",
     "nextMonth": "Next month"
+  },
+  "adminProxy": {
+    "banner": "Admin Proxy Booking Mode",
+    "bannerDesc": "Entering patient information from a phone reservation. Please confirm consent verbally over the phone."
   }
 }

--- a/oas-spa/src/i18n/locales/ja/admin.json
+++ b/oas-spa/src/i18n/locales/ja/admin.json
@@ -5,7 +5,8 @@
     "settings": "設定",
     "logout": "ログアウト",
     "lastLogin": "最終: ",
-    "consentPending": "利用規約・PP 確認待ち"
+    "consentPending": "利用規約・PP 確認待ち",
+    "proxyBooking": "代行予約"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/ja/booking.json
+++ b/oas-spa/src/i18n/locales/ja/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "前月",
     "nextMonth": "翌月"
+  },
+  "adminProxy": {
+    "banner": "管理者代行入力モード",
+    "bannerDesc": "電話予約を受けた患者の情報を入力しています。同意事項は電話口で口頭確認してください。"
   }
 }

--- a/oas-spa/src/i18n/locales/ko/admin.json
+++ b/oas-spa/src/i18n/locales/ko/admin.json
@@ -5,7 +5,8 @@
     "settings": "설정",
     "logout": "로그아웃",
     "lastLogin": "최근 로그인: ",
-    "consentPending": "약관 동의 필요"
+    "consentPending": "약관 동의 필요",
+    "proxyBooking": "대리 예약"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/ko/booking.json
+++ b/oas-spa/src/i18n/locales/ko/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "이전 달",
     "nextMonth": "다음 달"
+  },
+  "adminProxy": {
+    "banner": "관리자 대리 예약 모드",
+    "bannerDesc": "전화 예약 환자의 정보를 입력하고 있습니다. 동의 사항은 전화로 구두 확인해 주세요."
   }
 }

--- a/oas-spa/src/i18n/locales/pt-BR/admin.json
+++ b/oas-spa/src/i18n/locales/pt-BR/admin.json
@@ -5,7 +5,8 @@
     "settings": "Configurações",
     "logout": "Sair",
     "lastLogin": "Último acesso: ",
-    "consentPending": "Termos pendentes"
+    "consentPending": "Termos pendentes",
+    "proxyBooking": "Reservar para paciente"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/pt-BR/booking.json
+++ b/oas-spa/src/i18n/locales/pt-BR/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "Mês anterior",
     "nextMonth": "Próximo mês"
+  },
+  "adminProxy": {
+    "banner": "Modo de Reserva pelo Administrador",
+    "bannerDesc": "Inserindo informações do paciente de uma reserva por telefone. Confirme o consentimento verbalmente por telefone."
   }
 }

--- a/oas-spa/src/i18n/locales/tl/admin.json
+++ b/oas-spa/src/i18n/locales/tl/admin.json
@@ -5,7 +5,8 @@
     "settings": "Mga Setting",
     "logout": "Mag-logout",
     "lastLogin": "Huling login: ",
-    "consentPending": "Naghihintay ng pahintulot"
+    "consentPending": "Naghihintay ng pahintulot",
+    "proxyBooking": "Mag-book para sa pasyente"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/tl/booking.json
+++ b/oas-spa/src/i18n/locales/tl/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "Nakaraang buwan",
     "nextMonth": "Susunod na buwan"
+  },
+  "adminProxy": {
+    "banner": "Mode ng Pag-book ng Admin",
+    "bannerDesc": "Ini-input ang impormasyon ng pasyente mula sa telepono. Pakikumpirma ang pahintulot sa telepono."
   }
 }

--- a/oas-spa/src/i18n/locales/vi/admin.json
+++ b/oas-spa/src/i18n/locales/vi/admin.json
@@ -5,7 +5,8 @@
     "settings": "Cài Đặt",
     "logout": "Đăng Xuất",
     "lastLogin": "Đăng nhập lần cuối: ",
-    "consentPending": "Chờ xác nhận điều khoản"
+    "consentPending": "Chờ xác nhận điều khoản",
+    "proxyBooking": "Đặt hộ bệnh nhân"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/vi/booking.json
+++ b/oas-spa/src/i18n/locales/vi/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "Tháng trước",
     "nextMonth": "Tháng sau"
+  },
+  "adminProxy": {
+    "banner": "Chế Độ Đặt Lịch Hộ",
+    "bannerDesc": "Đang nhập thông tin bệnh nhân từ cuộc gọi đặt lịch. Vui lòng xác nhận đồng ý qua điện thoại."
   }
 }

--- a/oas-spa/src/i18n/locales/zh-CN/admin.json
+++ b/oas-spa/src/i18n/locales/zh-CN/admin.json
@@ -5,7 +5,8 @@
     "settings": "设置",
     "logout": "退出登录",
     "lastLogin": "最后登录: ",
-    "consentPending": "待同意条款"
+    "consentPending": "待同意条款",
+    "proxyBooking": "代客预约"
   },
   "dashboard": {
     "kpi": {

--- a/oas-spa/src/i18n/locales/zh-CN/booking.json
+++ b/oas-spa/src/i18n/locales/zh-CN/booking.json
@@ -174,5 +174,9 @@
   "calendar": {
     "prevMonth": "上个月",
     "nextMonth": "下个月"
+  },
+  "adminProxy": {
+    "banner": "管理员代理预约模式",
+    "bannerDesc": "正在录入电话预约的患者信息。请通过电话口头确认同意事项。"
   }
 }

--- a/oas-spa/src/pages/booking/Index.tsx
+++ b/oas-spa/src/pages/booking/Index.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { StepBar } from '@/components/shared/StepBar';
 import { DateTimeSelect } from './DateTimeSelect';
@@ -35,6 +36,8 @@ const INITIAL_FORM: ReservationFormData = {
 export default function BookingIndex() {
   const { t } = useTranslation('booking');
   const { showToast } = useToast();
+  const [searchParams] = useSearchParams();
+  const isAdminProxy = searchParams.get('admin') === '1';
   const [step, setStep] = useState(1);
   const [form, setForm] = useState<ReservationFormData>({ ...INITIAL_FORM });
 
@@ -64,7 +67,7 @@ export default function BookingIndex() {
     setSlotTakenMsg('');
     try {
       // メール送信はサーバーサイド（createReservation内部）で自動処理される
-      const { bookingId: id } = await createReservation(form);
+      const { bookingId: id } = await createReservation(form, isAdminProxy ? 'admin' : undefined);
       setBookingId(id);
 
       goToStep(4);
@@ -94,6 +97,19 @@ export default function BookingIndex() {
 
   return (
     <div>
+      {/* 管理者代行入力モードバナー */}
+      {isAdminProxy && step < 4 && (
+        <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 flex items-start gap-3">
+          <svg className="w-5 h-5 text-amber-600 mt-0.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+          </svg>
+          <div>
+            <p className="text-sm font-semibold text-amber-800">{t('adminProxy.banner')}</p>
+            <p className="text-xs text-amber-600 mt-0.5">{t('adminProxy.bannerDesc')}</p>
+          </div>
+        </div>
+      )}
+
       {step < 4 && <StepBar steps={STEPS} current={step} />}
 
       {slotTakenMsg && step === 1 && (


### PR DESCRIPTION
## Summary

- AdminLayout ナビに「代行予約」リンク追加（外部リンクアイコン付き、新規タブで `/?admin=1` を開く）
- booking/Index.tsx で `?admin=1` クエリパラメータを検出、アンバーのバナーで「管理者代行入力モード」を表示
- 送信時に `inputBy: 'admin'` フラグを Cloud Function に送信（監査ログ用）
- i18n: `layout.proxyBooking` (admin.json) + `adminProxy.banner/bannerDesc` (booking.json) を7言語に追加

## 法令チェック
- 電話口での口頭同意は医療機関の通常受付業務として許容範囲
- `inputBy: 'admin'` フラグで代行入力の記録を残す（監査対応）

## Test plan
- [ ] 管理者画面ナビに「代行予約」リンクが表示される
- [ ] クリックで新規タブが開き、`/?admin=1` に遷移
- [ ] アンバーのバナー「管理者代行入力モード」が表示される
- [ ] 予約完了後のデータに `inputBy: 'admin'` が含まれることを確認
- [ ] 通常アクセス(`/`)ではバナーが表示されないことを確認
- [ ] 7言語切替でバナー・ナビラベルが正しく表示される

🤖 Generated with [Claude Code](https://claude.ai/code)