### PR TITLE
患者別診察履歴管理 — 診察完了CF + 履歴画面 + APPI対応

### DIFF
--- a/documents/REMAINING_TASKS.md
+++ b/documents/REMAINING_TASKS.md
@@ -32,7 +32,8 @@
 | ✅ | OAS-UX-T04 | UI/UX改善（ペンディングバッジ、モーダルスクロール、最終ログイン表示、アナウンスバナー改行） | P2 |
 | ✅ | OAS-UX-T05 | ポリシー再生成機能（確認ダイアログ付き） | P2 |
 | ⬜ | OAS-UX-T01 | 管理ヘッダーにTOS確認アイコン（低優先） | P3 |
-| ⬜ | OAS-FUTURE-T01 | 多国語対応（i18n）— 7か国語、AMS同等 — 次セッションで着手予定 | P2 |
+| ✅ | OAS-FUTURE-T01 | 多国語対応（i18n）— 7か国語、AMS同等 | P2 |
+| ✅ | OAS-HIST-T01 | 患者別診察履歴管理（completeVisit CF + /admin/history画面 + Dashboard連携） | P1 |
 | ⬜ | OAS-FUTURE-T02 | 顧客管理システム（新規プロジェクト候補） | P3 |
 
 ## Security (SEC) — Remaining
@@ -52,7 +53,11 @@
 | ⬜ | CR-PR7 | リマインダーメール opt-out 機構（特定電子メール法対応） | P2 |
 | ⬜ | CR-PR7 | メール削除時の reminderEmailConsent リセット | P2 |
 | ⬜ | CR-PR7 | 新規Textareaフィールドの max-length 統一 | P3 |
-| ⬜ | CR-PR7 | iframe sandbox 属性追加 | P3 |
+| ⬜ | CR-PR7 | iframe sandbox 属性追加（PR #7で部分対応、Google Maps embed fix済み） | P3 |
 | ⬜ | CR-PR7 | 時刻フォーマットのゼロパディング互換性確認 | P3 |
+| ⬜ | CR-PR15 | visit_histories フルスキャン → ページネーション/クエリ上限対応（大規模データ対策） | P2 |
+| ⬜ | CR-PR15 | completeVisit CF: スロットステータス確認追加（二重完了防止強化） | P2 |
+| ⬜ | CR-PR15 | Dashboard KPI: `completed` ステータスを件数カウントに含める | P3 |
+| ⬜ | CR-PR15 | toLocaleString ロケールハードコード → i18n対応の日付フォーマット | P3 |
 
-**Completed: 29 / Remaining: 11**
+**Completed: 31 / Remaining: 15**

--- a/documents/WORKLOG.md
+++ b/documents/WORKLOG.md
@@ -11,6 +11,70 @@
 
 ---
 
+## 2026-03-24 Work Log (6)
+
+### Completed Tasks
+
+#### [OAS-HIST-T01] Patient Visit History Management (PR #15)
+
+Implemented full visit history feature for tracking completed appointments. Covers Cloud Function, Firestore collection, admin UI, dashboard integration, APPI compliance, i18n, and security.
+
+| Area | Details |
+|------|---------|
+| Cloud Function | `completeVisit` — Firestore transaction, duplicate prevention (409), admin auth check, rate limiting (SEC-11 pattern) |
+| Firestore | `visit_histories` collection — immutable (update/delete forbidden in rules), composite index added |
+| Admin Screen | `/admin/history` — search by name/zip/phone/date range, multi-sort (SortableHeader), CSV export, detail modal |
+| Dashboard | "診察完了" button added to confirmed reservations → transitions to completed status |
+| APPI Compliance | `retentionVisitHistoryNote` field in Settings (permanent retention justification), Privacy Policy placeholder updated |
+| Bug Fix | Google Maps embed sandbox attribute fix (`allow-popups` added) |
+| i18n | 7-language support (ja/en/ko/zh-CN/vi/pt-BR/tl) for all new UI |
+| Security | Firestore rules: `visit_histories` write-protected (admin create only, no update/delete); composite index deployed |
+
+#### Code Review (PR #15)
+
+- **Method**: 5 parallel agents
+- **Critical fix (score 100)**: Missing `isRateLimited` check in `completeVisit` CF (SEC-11 pattern) — fixed immediately, pushed as separate commit
+- **Sub-threshold findings (noted for future)**:
+  - Full collection snapshot scalability (score 75) — pagination/query limit for large datasets
+  - CF status check gap (score 75) — verify slot status before completing visit
+  - KPI counting completed reservations (score 75) — include `completed` status in KPI counts
+  - `toLocaleString` locale hardcoding (score 75) — replace with i18n-aware date formatting
+
+#### Notion Updates
+
+- Design spec page updated (visit history feature — implementation complete)
+- OAS legal compliance page updated (APPI `visit_histories` handling — permanent retention basis)
+- Labor law knowledge base updated (section 14: OAS visit history APPI compliance rationale)
+
+---
+
+## 2026-03-24 Work Log (5)
+
+### Completed Tasks
+
+#### [OAS-i18n] 7-Language Internationalization (PR #9)
+
+Implemented full i18n support for OAS using react-i18next. 3 parallel agents (A: booking, B: admin, C: infrastructure) worked concurrently to complete all translations and component updates.
+
+| Component | Details |
+|-----------|---------|
+| Libraries | react-i18next + i18next installed |
+| Languages | ja / en / zh-CN / vi / ko / pt-BR / tl (7 languages, matching AMS) |
+| Namespaces | common, auth, booking, admin, toast (5 namespaces) |
+| JSON files | 35 locale files created (5 × 7), ~550 keys total |
+| Components | All pages and components migrated from hardcoded Japanese to t() keys |
+| New component | LanguageSwitcher (globe icon + dropdown, Header-integrated) |
+| Legal | sensitiveDataBody key added — health info consent text now localized in 7 languages |
+| Bug fix | zh-CN/booking.json JSON syntax error fixed (unescaped double quotes in sensitiveDataBody) |
+
+### Agent Teams Pattern
+- Agent A (booking): booking.json × 7 langs + booking pages/components — 164 keys
+- Agent B (admin): admin.json + toast.json × 7 langs + admin pages — 251 keys
+- Agent C (infra): i18n/index.ts + common.json + auth.json + LanguageSwitcher + layout — 67 keys
+- All 3 ran in parallel, significant time savings vs sequential execution
+
+---
+
 ## 2026-03-24 Work Log (4)
 
 ### Completed Tasks

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -8,6 +8,15 @@
         { "fieldPath": "status", "order": "ASCENDING" }
       ]
     }
+    ,
+    {
+      "collectionGroup": "visit_histories",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "date", "order": "DESCENDING" },
+        { "fieldPath": "completedAt", "order": "DESCENDING" }
+      ]
+    }
   ],
   "fieldOverrides": []
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,7 +20,7 @@ service cloud.firestore {
         && data.phone    is string && data.phone.size()    <= 20
         && data.date     is string && data.date.size()     == 10
         && data.time     is string && data.time.size()     <= 10
-        && data.status   in ['pending','confirmed','cancelled']
+        && data.status   in ['pending','confirmed','cancelled','completed']
         // 任意フィールドの型・長さ検証
         && (!data.keys().hasAny(['email'])         || (data.email is string && data.email.size() <= 200))
         && (!data.keys().hasAny(['zip'])           || (data.zip is string && data.zip.size() <= 8))
@@ -75,6 +75,23 @@ service cloud.firestore {
           'privacyAcceptedAt',
           'termsVersion'
         ]);
+    }
+
+    // 診察履歴コレクション（管理者のみ読み書き可能 — 改ざん防止のため更新・削除不可）
+    match /visit_histories/{historyId} {
+      allow read: if isAdmin();
+      allow create: if isAdmin()
+        && request.resource.data.keys().hasAll([
+          'id', 'reservationId', 'name', 'phone', 'date', 'time',
+          'completedAt', 'completedBy', 'createdAt'
+        ])
+        && request.resource.data.name is string
+        && request.resource.data.name.size() <= 50
+        && request.resource.data.phone is string
+        && request.resource.data.phone.size() <= 20
+        && request.resource.data.date is string
+        && request.resource.data.date.size() == 10;
+      allow update, delete: if false;
     }
 
     // 監査ログコレクション（CSVエクスポート等の操作記録）

--- a/functions/index.js
+++ b/functions/index.js
@@ -989,6 +989,12 @@ exports.completeVisit = onRequest(
     if (req.method === "OPTIONS") { res.status(204).send(""); return; }
     if (req.method !== "POST")    { res.status(405).json({ error: "Method Not Allowed" }); return; }
 
+    // [SEC-11] レート制限
+    const clientIp = (req.headers["x-forwarded-for"] || "").split(",")[0].trim() || req.ip;
+    if (isRateLimited(clientIp)) {
+      res.status(429).json({ error: "リクエストが多すぎます。しばらくお待ちください。" }); return;
+    }
+
     // ── 管理者認証チェック ──
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith("Bearer ")) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -980,3 +980,109 @@ exports.sendDailyReminders = onSchedule(
     console.log(`リマインダー送信完了: ${tasks.length} 件 (${tomorrowStr})`);
   }
 );
+
+// ── 診察完了（visit_histories にスナップショット保存 + ステータス更新）──
+exports.completeVisit = onRequest(
+  { invoker: "public" },
+  async (req, res) => {
+    setCorsHeaders(req, res);
+    if (req.method === "OPTIONS") { res.status(204).send(""); return; }
+    if (req.method !== "POST")    { res.status(405).json({ error: "Method Not Allowed" }); return; }
+
+    // ── 管理者認証チェック ──
+    const authHeader = req.headers.authorization;
+    if (!authHeader?.startsWith("Bearer ")) {
+      res.status(401).json({ error: "認証が必要です" }); return;
+    }
+    let decoded;
+    try {
+      decoded = await getAuth().verifyIdToken(authHeader.split("Bearer ")[1]);
+      if (!decoded.admin) { res.status(403).json({ error: "管理者権限が必要です" }); return; }
+    } catch (_) {
+      res.status(401).json({ error: "認証トークンが無効です" }); return;
+    }
+
+    const { reservationId } = req.body;
+    if (!reservationId || typeof reservationId !== "string" || reservationId.length > 100) {
+      res.status(400).json({ error: "予約IDが不正です" }); return;
+    }
+
+    const db = getFirestore();
+
+    try {
+      const result = await db.runTransaction(async (tx) => {
+        // 予約ドキュメント取得
+        const resRef  = db.collection("reservations").doc(reservationId);
+        const resSnap = await tx.get(resRef);
+        if (!resSnap.exists) return { status: 404, error: "予約が見つかりません" };
+
+        // 二重完了防止
+        const dupQuery = db.collection("visit_histories").where("reservationId", "==", reservationId).limit(1);
+        const dupSnap  = await tx.get(dupQuery);
+        if (!dupSnap.empty) return { status: 409, error: "ALREADY_COMPLETED" };
+
+        const booking = resSnap.data();
+        const now     = new Date().toISOString();
+        const histRef = db.collection("visit_histories").doc();
+
+        // スナップショット作成
+        const snapshot = {
+          id:                      histRef.id,
+          reservationId,
+          // 患者情報
+          date:                    booking.date    || "",
+          time:                    booking.time    || "",
+          name:                    booking.name    || "",
+          furigana:                booking.furigana || "",
+          birthdate:               booking.birthdate || "",
+          zip:                     booking.zip     || "",
+          address:                 booking.address || "",
+          phone:                   booking.phone   || "",
+          email:                   booking.email   || "",
+          gender:                  booking.gender  || "",
+          visitType:               booking.visitType || "",
+          insurance:               booking.insurance || "",
+          symptoms:                booking.symptoms || "",
+          notes:                   booking.notes   || "",
+          contactMethod:           booking.contactMethod || "",
+          hasSensitiveDataConsent: booking.hasSensitiveDataConsent || false,
+          reminderEmailConsent:    booking.reminderEmailConsent || false,
+          // 予約メタデータ
+          reservationCreatedAt:    booking.createdAt || "",
+          reservationStatus:       booking.status || "",
+          // キャンセル情報（あれば）
+          ...(booking.cancelledBy  ? { cancelledBy: booking.cancelledBy }   : {}),
+          ...(booking.cancelReason ? { cancelReason: booking.cancelReason } : {}),
+          ...(booking.cancelledAt  ? { cancelledAt: booking.cancelledAt }   : {}),
+          // 診察完了メタデータ
+          completedAt:             now,
+          completedBy:             decoded.uid,
+          completedByEmail:        decoded.email || "",
+          createdAt:               now,
+        };
+
+        tx.create(histRef, snapshot);
+        tx.update(resRef, { status: "completed" });
+
+        return { status: 200, visitHistoryId: histRef.id };
+      });
+
+      if (result.status !== 200) {
+        res.status(result.status).json({ error: result.error });
+        return;
+      }
+
+      auditLog("visit_completed", {
+        reservationId,
+        visitHistoryId: result.visitHistoryId,
+        adminUid: decoded.uid,
+        adminEmail: decoded.email,
+      });
+
+      res.status(200).json({ ok: true, visitHistoryId: result.visitHistoryId });
+    } catch (err) {
+      console.error("completeVisit エラー:", err);
+      res.status(500).json({ error: "内部エラーが発生しました" });
+    }
+  }
+);

--- a/oas-spa/src/App.tsx
+++ b/oas-spa/src/App.tsx
@@ -17,6 +17,7 @@ import PrivacyPolicy from '@/pages/PrivacyPolicy';
 import Login from '@/pages/Login';
 import AuthAction from '@/pages/AuthAction';
 import Dashboard from '@/pages/admin/Dashboard';
+import VisitHistory from '@/pages/admin/VisitHistory';
 import Settings from '@/pages/admin/Settings';
 import ChangePassword from '@/pages/admin/ChangePassword';
 import Maintenance from '@/pages/Maintenance';
@@ -46,6 +47,7 @@ export default function App() {
                 {/* 管理者ページ */}
                 <Route element={<AdminLayout />}>
                   <Route path="/admin" element={<Dashboard />} />
+                  <Route path="/admin/history" element={<VisitHistory />} />
                   <Route path="/admin/settings" element={<Settings />} />
                   <Route path="/admin/change-password" element={<ChangePassword />} />
                 </Route>

--- a/oas-spa/src/components/layout/AdminLayout.tsx
+++ b/oas-spa/src/components/layout/AdminLayout.tsx
@@ -57,6 +57,16 @@ export function AdminLayout() {
                 )}
               </Link>
               <Link
+                to="/admin/history"
+                className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
+                  location.pathname.includes('/history')
+                    ? 'bg-white/10 text-cream'
+                    : 'text-cream/60 hover:text-cream hover:bg-white/5'
+                }`}
+              >
+                {t('layout.visitHistory')}
+              </Link>
+              <Link
                 to="/admin/settings"
                 className={`px-3 py-1.5 rounded-md text-sm font-medium transition-all duration-200 ${
                   location.pathname.includes('/settings')

--- a/oas-spa/src/components/shared/ConfirmDialog.tsx
+++ b/oas-spa/src/components/shared/ConfirmDialog.tsx
@@ -9,6 +9,7 @@ interface ConfirmDialogProps {
   okLabel?: string;
   cancelLabel?: string;
   variant?: 'primary' | 'danger';
+  loading?: boolean;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -18,6 +19,7 @@ export function ConfirmDialog({
   okLabel,
   cancelLabel,
   variant = 'primary',
+  loading,
   onConfirm, onCancel,
 }: ConfirmDialogProps) {
   const { t } = useTranslation('common');
@@ -28,8 +30,8 @@ export function ConfirmDialog({
     <Modal open={open} onClose={onCancel} title={title}>
       <p className="text-sm text-navy-500 mb-6">{message}</p>
       <div className="flex justify-end gap-3">
-        <Button variant="ghost" onClick={onCancel}>{resolvedCancelLabel}</Button>
-        <Button variant={variant === 'danger' ? 'danger' : 'primary'} onClick={onConfirm}>{resolvedOkLabel}</Button>
+        <Button variant="ghost" onClick={onCancel} disabled={loading}>{resolvedCancelLabel}</Button>
+        <Button variant={variant === 'danger' ? 'danger' : 'primary'} onClick={onConfirm} loading={loading}>{resolvedOkLabel}</Button>
       </div>
     </Modal>
   );

--- a/oas-spa/src/hooks/useAdmin.ts
+++ b/oas-spa/src/hooks/useAdmin.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { collection, onSnapshot, doc, writeBatch, addDoc, query, where } from 'firebase/firestore';
 import { db, auth } from '@/lib/firebase';
 import { callFunction } from '@/lib/functions';
-import type { ReservationRecord, ReservationStatus } from '@/types/reservation';
+import type { ReservationRecord, ReservationStatus, VisitHistoryRecord } from '@/types/reservation';
 
 /** 未確認予約件数リアルタイムリスナー（ヘッダーバッジ用） */
 export function usePendingCount() {
@@ -154,6 +154,75 @@ export function exportReservationsCsv(
   } catch {
     // 同期エラー時もCSVエクスポートは続行
   }
+}
+
+/** 診察完了処理（CF呼び出し） */
+export async function completeVisit(reservationId: string): Promise<{ visitHistoryId: string }> {
+  return callFunction<{ visitHistoryId: string }>('completeVisit', { reservationId });
+}
+
+/** 診察履歴リアルタイムリスナー */
+export function useVisitHistories() {
+  const [histories, setHistories] = useState<VisitHistoryRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onSnapshot(
+      collection(db, 'visit_histories'),
+      (snap) => {
+        const data = snap.docs.map(d => ({ ...d.data(), id: d.id }) as VisitHistoryRecord);
+        // 診察日降順ソート
+        data.sort((a, b) => {
+          const da = `${a.date} ${a.time}`;
+          const db_ = `${b.date} ${b.time}`;
+          return db_.localeCompare(da);
+        });
+        setHistories(data);
+        setLoading(false);
+      },
+      () => setLoading(false),
+    );
+    return unsubscribe;
+  }, []);
+
+  return { histories, loading };
+}
+
+/** 診察履歴CSV出力（監査ログ付き） */
+export function exportVisitHistoriesCsv(
+  histories: VisitHistoryRecord[],
+  labels: { headers: string[]; statusLabels: Record<string, string>; filename: string },
+): void {
+  const escape = (v: string) => `"${(v || '').replace(/"/g, '""')}"`;
+
+  const rows = histories.map(r => [
+    r.reservationId, r.date, r.time, r.name, r.furigana, r.birthdate,
+    r.address, r.phone, r.email, r.gender,
+    r.visitType, r.insurance, r.symptoms, r.notes,
+    r.contactMethod, labels.statusLabels[r.reservationStatus] || r.reservationStatus,
+    r.reservationCreatedAt,
+    r.completedAt ? new Date(r.completedAt).toLocaleString('ja-JP') : '',
+    r.completedByEmail,
+  ].map(escape).join(','));
+
+  const csv = '\uFEFF' + [labels.headers.join(','), ...rows].join('\r\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = labels.filename;
+  a.click();
+  URL.revokeObjectURL(url);
+
+  try {
+    addDoc(collection(db, 'audit_logs'), {
+      action: 'visit_history_csv_export',
+      adminUid: auth.currentUser?.uid,
+      adminEmail: auth.currentUser?.email,
+      recordCount: histories.length,
+      timestamp: new Date().toISOString(),
+    }).catch(() => {});
+  } catch { /* 監査ログ失敗時もCSV続行 */ }
 }
 
 /** メールアドレスマスキング */

--- a/oas-spa/src/i18n/locales/en/admin.json
+++ b/oas-spa/src/i18n/locales/en/admin.json
@@ -6,7 +6,8 @@
     "logout": "Logout",
     "lastLogin": "Last: ",
     "consentPending": "ToS / Privacy Pending",
-    "proxyBooking": "Book for Patient"
+    "proxyBooking": "Book for Patient",
+    "visitHistory": "Visit History"
   },
   "dashboard": {
     "kpi": {
@@ -20,6 +21,7 @@
       "pending": "Unconfirmed",
       "confirmed": "Confirmed",
       "cancelled": "Cancelled",
+      "completed": "Completed",
       "csvExport": "Export CSV",
       "clearFilters": "Clear"
     },
@@ -40,12 +42,14 @@
       "symptoms": "Symptoms",
       "phone": "Phone",
       "reservationDate": "Booking Date",
-      "status": "Status"
+      "status": "Status",
+      "clearSort": "Clear Sort"
     },
     "status": {
       "pending": "Unconfirmed",
       "confirmed": "Confirmed",
       "cancelled": "Cancelled",
+      "completed": "Completed",
       "cancelledByAdmin": "Admin",
       "cancelledByPatient": "Patient"
     },
@@ -57,6 +61,7 @@
       "reservationDetail": "Reservation Details",
       "close": "Close",
       "markConfirmed": "Mark as Confirmed",
+      "markCompleted": "Complete Visit",
       "cancel": "Cancel",
       "fields": {
         "reservationId": "Booking ID",
@@ -81,7 +86,9 @@
         "cancelledBy": "Cancelled By",
         "cancelReason": "Cancel Reason",
         "cancelledAt": "Cancelled At",
-        "createdAt": "Booking Date"
+        "createdAt": "Booking Date",
+        "completedAt": "Completed At",
+        "completedBy": "Completed By"
       },
       "symptomsTitle": "{{name}} — Symptoms",
       "notesLabel": "Notes"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "Change Status",
       "statusChangeMessage": "Mark {{name}}'s reservation as confirmed?",
-      "okLabel": "Mark as Confirmed"
+      "okLabel": "Mark as Confirmed",
+      "completeTitle": "Complete Visit",
+      "completeMessage": "Mark {{name}}'s visit as completed? This will be saved to visit history.",
+      "completeOkLabel": "Mark as Completed"
     },
     "cancelModal": {
       "title": "Cancel Reservation",
@@ -112,6 +122,47 @@
       "date": "Date",
       "time": "Time",
       "filename": "reservations_"
+    }
+  },
+  "history": {
+    "title": "Visit History",
+    "search": {
+      "name": "Name",
+      "namePlaceholder": "Yamada Taro",
+      "zip": "Postal Code",
+      "zipPlaceholder": "123-4567",
+      "phone": "Phone",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "Visit Date From",
+      "visitDateTo": "Visit Date To"
+    },
+    "filter": {
+      "clearFilters": "Clear Search",
+      "csvExport": "Export CSV"
+    },
+    "table": {
+      "visitDateTime": "Visit Date/Time",
+      "name": "Name",
+      "visitType": "Visit",
+      "phone": "Phone",
+      "clearSort": "Clear Sort"
+    },
+    "action": {
+      "detail": "View"
+    },
+    "emptyState": "No visit history found",
+    "modal": {
+      "historyDetail": "Visit History Details",
+      "close": "Close",
+      "fields": {
+        "completedAt": "Completed At",
+        "completedBy": "Completed By"
+      }
+    },
+    "csv": {
+      "date": "Visit Date",
+      "time": "Visit Time",
+      "filename": "visit-history_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "Purpose of Use (APPI Article 17)",
       "usagePurposeHint": "Displayed in the privacy policy and booking form.",
       "retentionLegalNote": "Set the retention period within the scope necessary for achieving the purpose of use. Data past the retention period will be notified to admins for manual deletion.",
+      "retentionVisitHistoryNote": "* Visit history (completed consultation records) is excluded from data retention policy. It is permanently retained as medical records regardless of retention period settings. Please inform patients via your privacy policy.",
       "reminderEmailTitle": "Reminder Email",
       "reminderEmailLabel": "Enable reminder email feature",
       "reminderEmailHint": "When enabled, patients can opt-in to receive a reminder email the day before their appointment.",

--- a/oas-spa/src/i18n/locales/en/toast.json
+++ b/oas-spa/src/i18n/locales/en/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "Maximum {{max}} users allowed.",
   "emailPasswordRequired": "Please enter email and password",
   "invalidEmail": "Invalid email address format",
-  "passwordChanged": "Password changed successfully"
+  "passwordChanged": "Password changed successfully",
+  "visitCompleted": "Visit marked as completed",
+  "alreadyCompleted": "This reservation is already completed"
 }

--- a/oas-spa/src/i18n/locales/ja/admin.json
+++ b/oas-spa/src/i18n/locales/ja/admin.json
@@ -6,7 +6,8 @@
     "logout": "ログアウト",
     "lastLogin": "最終: ",
     "consentPending": "利用規約・PP 確認待ち",
-    "proxyBooking": "代行予約"
+    "proxyBooking": "代行予約",
+    "visitHistory": "診察履歴"
   },
   "dashboard": {
     "kpi": {
@@ -20,6 +21,7 @@
       "pending": "未確認",
       "confirmed": "確認済み",
       "cancelled": "キャンセル",
+      "completed": "診察完了",
       "csvExport": "CSV出力",
       "clearFilters": "クリア"
     },
@@ -40,14 +42,16 @@
       "symptoms": "症状",
       "phone": "電話",
       "reservationDate": "予約受付日",
-      "status": "ステータス"
+      "status": "ステータス",
+      "clearSort": "ソートクリア"
     },
     "status": {
       "pending": "未確認",
       "confirmed": "確認済み",
       "cancelled": "キャンセル",
       "cancelledByAdmin": "管理者",
-      "cancelledByPatient": "患者"
+      "cancelledByPatient": "患者",
+      "completed": "診察完了"
     },
     "action": {
       "detail": "詳細"
@@ -57,6 +61,7 @@
       "reservationDetail": "予約詳細",
       "close": "閉じる",
       "markConfirmed": "確認済みにする",
+      "markCompleted": "診察完了",
       "cancel": "キャンセル",
       "fields": {
         "reservationId": "予約番号",
@@ -81,7 +86,9 @@
         "cancelledBy": "キャンセル元",
         "cancelReason": "キャンセル理由",
         "cancelledAt": "キャンセル日時",
-        "createdAt": "予約受付日"
+        "createdAt": "予約受付日",
+        "completedAt": "診察完了日時",
+        "completedBy": "完了操作者"
       },
       "symptomsTitle": "{{name}}様 — 症状",
       "notesLabel": "伝達事項"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "ステータス変更",
       "statusChangeMessage": "{{name}}様の予約を確認済みにしますか？",
-      "okLabel": "確認済みにする"
+      "okLabel": "確認済みにする",
+      "completeTitle": "診察完了",
+      "completeMessage": "{{name}}様の診察を完了としてマークしますか？診察履歴に保存されます。",
+      "completeOkLabel": "完了にする"
     },
     "cancelModal": {
       "title": "予約キャンセル",
@@ -112,6 +122,47 @@
       "date": "予約日",
       "time": "予約時間",
       "filename": "予約データ_"
+    }
+  },
+  "history": {
+    "title": "診察履歴",
+    "search": {
+      "name": "氏名",
+      "namePlaceholder": "山田太郎",
+      "zip": "郵便番号",
+      "zipPlaceholder": "123-4567",
+      "phone": "電話番号",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "診察日From",
+      "visitDateTo": "診察日To"
+    },
+    "filter": {
+      "clearFilters": "検索クリア",
+      "csvExport": "CSV出力"
+    },
+    "table": {
+      "visitDateTime": "診療日時",
+      "name": "氏名",
+      "visitType": "初/再",
+      "phone": "電話",
+      "clearSort": "ソートクリア"
+    },
+    "action": {
+      "detail": "詳細"
+    },
+    "emptyState": "診察履歴がありません",
+    "modal": {
+      "historyDetail": "診察履歴詳細",
+      "close": "閉じる",
+      "fields": {
+        "completedAt": "診察完了日時",
+        "completedBy": "完了操作者"
+      }
+    },
+    "csv": {
+      "date": "診察日",
+      "time": "診察時間",
+      "filename": "診察履歴_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "個人情報の利用目的（APPI 第17条）",
       "usagePurposeHint": "プライバシーポリシーおよび予約フォームに表示されます。空欄の場合はプレースホルダーの内容が使用されます。",
       "retentionLegalNote": "個人情報保護法に基づき、利用目的の達成に必要な範囲で保存期間を設定してください。保存期間を過ぎたデータは管理者に通知され、手動で削除できます。",
+      "retentionVisitHistoryNote": "※ 診察履歴（診察完了記録）はデータ保存期間の対象外です。医療記録として保存期間設定に関わらず永久に保持されます。患者にはプライバシーポリシーで告知してください。",
       "reminderEmailTitle": "リマインダーメール配信",
       "reminderEmailLabel": "リマインダーメール機能を有効にする",
       "reminderEmailHint": "有効にすると、予約フォームに「リマインダーメールを受け取る」同意チェックが表示されます。同意した患者にのみ予約前日のリマインダーメールが送信されます。",

--- a/oas-spa/src/i18n/locales/ja/toast.json
+++ b/oas-spa/src/i18n/locales/ja/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "ユーザーの登録上限は{{max}}人までです。",
   "emailPasswordRequired": "メールとパスワードを入力してください",
   "invalidEmail": "メールアドレスの形式が正しくありません",
-  "passwordChanged": "パスワードを変更しました"
+  "passwordChanged": "パスワードを変更しました",
+  "visitCompleted": "診察完了として記録しました",
+  "alreadyCompleted": "この予約は既に診察完了済みです"
 }

--- a/oas-spa/src/i18n/locales/ko/admin.json
+++ b/oas-spa/src/i18n/locales/ko/admin.json
@@ -6,7 +6,8 @@
     "logout": "로그아웃",
     "lastLogin": "최근 로그인: ",
     "consentPending": "약관 동의 필요",
-    "proxyBooking": "대리 예약"
+    "proxyBooking": "대리 예약",
+    "visitHistory": "진찰 이력"
   },
   "dashboard": {
     "kpi": {
@@ -21,7 +22,8 @@
       "confirmed": "확인됨",
       "cancelled": "취소됨",
       "csvExport": "CSV 내보내기",
-      "clearFilters": "필터 지우기"
+      "clearFilters": "필터 지우기",
+      "completed": "진찰 완료"
     },
     "search": {
       "name": "이름",
@@ -40,14 +42,16 @@
       "symptoms": "증상",
       "phone": "전화번호",
       "reservationDate": "예약 접수일",
-      "status": "상태"
+      "status": "상태",
+      "clearSort": "정렬 초기화"
     },
     "status": {
       "pending": "미확인",
       "confirmed": "확인됨",
       "cancelled": "취소됨",
       "cancelledByAdmin": "관리자",
-      "cancelledByPatient": "환자"
+      "cancelledByPatient": "환자",
+      "completed": "진찰 완료"
     },
     "action": {
       "detail": "상세보기"
@@ -57,6 +61,7 @@
       "reservationDetail": "예약 상세",
       "close": "닫기",
       "markConfirmed": "확인됨으로 표시",
+      "markCompleted": "진찰 완료",
       "cancel": "취소",
       "fields": {
         "reservationId": "예약 번호",
@@ -81,7 +86,9 @@
         "cancelledBy": "취소한 사람",
         "cancelReason": "취소 이유",
         "cancelledAt": "취소 일시",
-        "createdAt": "예약 접수일"
+        "createdAt": "예약 접수일",
+        "completedAt": "진찰 완료 일시",
+        "completedBy": "완료 처리자"
       },
       "symptomsTitle": "{{name}}님 — 증상",
       "notesLabel": "전달 사항"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "상태 변경",
       "statusChangeMessage": "{{name}}님의 예약을 확인됨으로 표시하시겠습니까?",
-      "okLabel": "확인됨으로 표시"
+      "okLabel": "확인됨으로 표시",
+      "completeTitle": "진찰 완료",
+      "completeMessage": "{{name}}님의 진찰을 완료로 표시하시겠습니까? 진찰 이력에 저장됩니다.",
+      "completeOkLabel": "완료 처리"
     },
     "cancelModal": {
       "title": "예약 취소",
@@ -112,6 +122,47 @@
       "date": "예약일",
       "time": "예약시간",
       "filename": "예약데이터_"
+    }
+  },
+  "history": {
+    "title": "진찰 이력",
+    "search": {
+      "name": "성명",
+      "namePlaceholder": "야마다 타로",
+      "zip": "우편번호",
+      "zipPlaceholder": "123-4567",
+      "phone": "전화번호",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "진료일 From",
+      "visitDateTo": "진료일 To"
+    },
+    "filter": {
+      "clearFilters": "검색 초기화",
+      "csvExport": "CSV 내보내기"
+    },
+    "table": {
+      "visitDateTime": "진료 일시",
+      "name": "성명",
+      "visitType": "초/재진",
+      "phone": "전화",
+      "clearSort": "정렬 초기화"
+    },
+    "action": {
+      "detail": "상세"
+    },
+    "emptyState": "진찰 이력이 없습니다",
+    "modal": {
+      "historyDetail": "진찰 이력 상세",
+      "close": "닫기",
+      "fields": {
+        "completedAt": "진찰 완료 일시",
+        "completedBy": "완료 처리자"
+      }
+    },
+    "csv": {
+      "date": "진찰일",
+      "time": "진찰 시간",
+      "filename": "진찰이력_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "개인정보 이용 목적 (APPI 제17조)",
       "usagePurposeHint": "개인정보 처리방침 및 예약 양식에 표시됩니다.",
       "retentionLegalNote": "개인정보 보호법에 따라 이용 목적 달성에 필요한 범위 내에서 보존 기간을 설정하십시오. 보존 기간이 지난 데이터는 관리자에게 통보되어 수동으로 삭제할 수 있습니다.",
+      "retentionVisitHistoryNote": "※ 진료 이력(진료 완료 기록)은 데이터 보존 기간 대상에서 제외됩니다. 의료 기록으로서 보존 기간 설정에 관계없이 영구적으로 보존됩니다. 개인정보 처리방침을 통해 환자에게 고지해 주세요.",
       "reminderEmailTitle": "리마인더 이메일",
       "reminderEmailLabel": "리마인더 이메일 기능 활성화",
       "reminderEmailHint": "활성화하면 예약 양식에 리마인더 이메일 수신 동의 체크박스가 표시됩니다. 동의한 환자에게만 전날 리마인더가 발송됩니다.",

--- a/oas-spa/src/i18n/locales/ko/toast.json
+++ b/oas-spa/src/i18n/locales/ko/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "최대 {{max}}명의 사용자만 등록할 수 있습니다.",
   "emailPasswordRequired": "이메일과 비밀번호를 입력하세요",
   "invalidEmail": "이메일 주소 형식이 올바르지 않습니다",
-  "passwordChanged": "비밀번호가 변경되었습니다"
+  "passwordChanged": "비밀번호가 변경되었습니다",
+  "visitCompleted": "진찰 완료로 기록되었습니다",
+  "alreadyCompleted": "이 예약은 이미 진찰 완료 상태입니다"
 }

--- a/oas-spa/src/i18n/locales/pt-BR/admin.json
+++ b/oas-spa/src/i18n/locales/pt-BR/admin.json
@@ -6,7 +6,8 @@
     "logout": "Sair",
     "lastLogin": "Último acesso: ",
     "consentPending": "Termos pendentes",
-    "proxyBooking": "Reservar para paciente"
+    "proxyBooking": "Reservar para paciente",
+    "visitHistory": "Histórico de Consultas"
   },
   "dashboard": {
     "kpi": {
@@ -20,6 +21,7 @@
       "pending": "Não Confirmados",
       "confirmed": "Confirmados",
       "cancelled": "Cancelados",
+      "completed": "Consulta Concluída",
       "csvExport": "Exportar CSV",
       "clearFilters": "Limpar"
     },
@@ -40,12 +42,14 @@
       "symptoms": "Sintomas",
       "phone": "Telefone",
       "reservationDate": "Data da Reserva",
-      "status": "Status"
+      "status": "Status",
+      "clearSort": "Limpar Ordenação"
     },
     "status": {
       "pending": "Não Confirmado",
       "confirmed": "Confirmado",
       "cancelled": "Cancelado",
+      "completed": "Consulta Concluída",
       "cancelledByAdmin": "Administrador",
       "cancelledByPatient": "Paciente"
     },
@@ -57,6 +61,7 @@
       "reservationDetail": "Detalhes da Reserva",
       "close": "Fechar",
       "markConfirmed": "Marcar como Confirmado",
+      "markCompleted": "Concluir Consulta",
       "cancel": "Cancelar",
       "fields": {
         "reservationId": "Nº da Reserva",
@@ -81,7 +86,9 @@
         "cancelledBy": "Cancelado por",
         "cancelReason": "Motivo do Cancelamento",
         "cancelledAt": "Data do Cancelamento",
-        "createdAt": "Data da Reserva"
+        "createdAt": "Data da Reserva",
+        "completedAt": "Concluído em",
+        "completedBy": "Concluído por"
       },
       "symptomsTitle": "Sintomas de {{name}}",
       "notesLabel": "Observações"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "Alterar Status",
       "statusChangeMessage": "Marcar a reserva de {{name}} como confirmada?",
-      "okLabel": "Marcar como Confirmado"
+      "okLabel": "Marcar como Confirmado",
+      "completeTitle": "Concluir Consulta",
+      "completeMessage": "Marcar a consulta de {{name}} como concluída? Será salvo no histórico de consultas.",
+      "completeOkLabel": "Marcar como Concluída"
     },
     "cancelModal": {
       "title": "Cancelar Reserva",
@@ -112,6 +122,47 @@
       "date": "Data",
       "time": "Horário",
       "filename": "reservas_"
+    }
+  },
+  "history": {
+    "title": "Histórico de Consultas",
+    "search": {
+      "name": "Nome",
+      "namePlaceholder": "Yamada Taro",
+      "zip": "CEP",
+      "zipPlaceholder": "123-4567",
+      "phone": "Telefone",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "Data da consulta De",
+      "visitDateTo": "Data da consulta Até"
+    },
+    "filter": {
+      "clearFilters": "Limpar Busca",
+      "csvExport": "Exportar CSV"
+    },
+    "table": {
+      "visitDateTime": "Data/Hora da consulta",
+      "name": "Nome",
+      "visitType": "Tipo",
+      "phone": "Telefone",
+      "clearSort": "Limpar Ordenação"
+    },
+    "action": {
+      "detail": "Detalhes"
+    },
+    "emptyState": "Nenhum histórico de consulta encontrado",
+    "modal": {
+      "historyDetail": "Detalhes do Histórico",
+      "close": "Fechar",
+      "fields": {
+        "completedAt": "Concluído em",
+        "completedBy": "Concluído por"
+      }
+    },
+    "csv": {
+      "date": "Data da consulta",
+      "time": "Hora da consulta",
+      "filename": "historico-consultas_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "Finalidade do Uso de Dados Pessoais (APPI Art. 17)",
       "usagePurposeHint": "Exibido na política de privacidade e no formulário de reserva.",
       "retentionLegalNote": "Defina o período de retenção dentro do escopo necessário para atingir a finalidade de uso. Os dados vencidos serão notificados aos administradores para exclusão manual.",
+      "retentionVisitHistoryNote": "※ O histórico de consultas (registros de consultas concluídas) está excluído da política de retenção de dados. É mantido permanentemente como registro médico, independentemente das configurações do período de retenção. Informe os pacientes através da sua política de privacidade.",
       "reminderEmailTitle": "E-mail de Lembrete",
       "reminderEmailLabel": "Ativar função de e-mail de lembrete",
       "reminderEmailHint": "Quando ativado, o formulário de reserva exibirá uma caixa de seleção de consentimento para e-mails de lembrete. Lembretes são enviados somente a pacientes que consentiram.",

--- a/oas-spa/src/i18n/locales/pt-BR/toast.json
+++ b/oas-spa/src/i18n/locales/pt-BR/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "Máximo de {{max}} usuários permitidos.",
   "emailPasswordRequired": "Por favor, insira e-mail e senha",
   "invalidEmail": "Formato de endereço de e-mail inválido",
-  "passwordChanged": "Senha alterada com sucesso"
+  "passwordChanged": "Senha alterada com sucesso",
+  "visitCompleted": "Consulta marcada como concluída",
+  "alreadyCompleted": "Esta reserva já foi concluída"
 }

--- a/oas-spa/src/i18n/locales/tl/admin.json
+++ b/oas-spa/src/i18n/locales/tl/admin.json
@@ -6,7 +6,8 @@
     "logout": "Mag-logout",
     "lastLogin": "Huling login: ",
     "consentPending": "Naghihintay ng pahintulot",
-    "proxyBooking": "Mag-book para sa pasyente"
+    "proxyBooking": "Mag-book para sa pasyente",
+    "visitHistory": "Kasaysayan ng Konsultasyon"
   },
   "dashboard": {
     "kpi": {
@@ -20,6 +21,7 @@
       "pending": "Hindi Pa Nakumpirma",
       "confirmed": "Nakumpirma",
       "cancelled": "Nakansela",
+      "completed": "Nakumpleto",
       "csvExport": "I-export ang CSV",
       "clearFilters": "I-clear"
     },
@@ -40,12 +42,14 @@
       "symptoms": "Mga Sintomas",
       "phone": "Telepono",
       "reservationDate": "Petsa ng Reserbacyon",
-      "status": "Katayuan"
+      "status": "Katayuan",
+      "clearSort": "I-clear ang Pagkakaayos"
     },
     "status": {
       "pending": "Hindi Pa Nakumpirma",
       "confirmed": "Nakumpirma",
       "cancelled": "Nakansela",
+      "completed": "Nakumpleto",
       "cancelledByAdmin": "Admin",
       "cancelledByPatient": "Pasyente"
     },
@@ -57,6 +61,7 @@
       "reservationDetail": "Detalye ng Reserbacyon",
       "close": "Isara",
       "markConfirmed": "Markahan bilang Nakumpirma",
+      "markCompleted": "Kumpletuhin ang Konsultasyon",
       "cancel": "Kanselahin",
       "fields": {
         "reservationId": "Blg. ng Reserbacyon",
@@ -81,7 +86,9 @@
         "cancelledBy": "Kinansela ng",
         "cancelReason": "Dahilan ng Pagkansela",
         "cancelledAt": "Petsa ng Pagkansela",
-        "createdAt": "Petsa ng Reserbacyon"
+        "createdAt": "Petsa ng Reserbacyon",
+        "completedAt": "Nakumpleto Noong",
+        "completedBy": "Kinumpleto Ng"
       },
       "symptomsTitle": "Mga Sintomas ni {{name}}",
       "notesLabel": "Mga Tala"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "Baguhin ang Katayuan",
       "statusChangeMessage": "Markahan ang reserbacyon ni {{name}} bilang nakumpirma?",
-      "okLabel": "Markahan bilang Nakumpirma"
+      "okLabel": "Markahan bilang Nakumpirma",
+      "completeTitle": "Kumpletuhin ang Konsultasyon",
+      "completeMessage": "Markahan ang konsultasyon ni {{name}} bilang nakumpleto? Ise-save sa kasaysayan ng konsultasyon.",
+      "completeOkLabel": "Markahan bilang Nakumpleto"
     },
     "cancelModal": {
       "title": "Kanselahin ang Reserbacyon",
@@ -112,6 +122,47 @@
       "date": "Petsa",
       "time": "Oras",
       "filename": "mga-reserbacyon_"
+    }
+  },
+  "history": {
+    "title": "Kasaysayan ng Konsultasyon",
+    "search": {
+      "name": "Pangalan",
+      "namePlaceholder": "Yamada Taro",
+      "zip": "Zip Code",
+      "zipPlaceholder": "123-4567",
+      "phone": "Telepono",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "Petsa ng Konsulta Mula",
+      "visitDateTo": "Petsa ng Konsulta Hanggang"
+    },
+    "filter": {
+      "clearFilters": "I-clear ang Paghahanap",
+      "csvExport": "I-export ang CSV"
+    },
+    "table": {
+      "visitDateTime": "Petsa/Oras ng Konsultasyon",
+      "name": "Pangalan",
+      "visitType": "Uri ng Bisita",
+      "phone": "Telepono",
+      "clearSort": "I-clear ang Pagkakaayos"
+    },
+    "action": {
+      "detail": "Detalye"
+    },
+    "emptyState": "Walang kasaysayan ng konsultasyon",
+    "modal": {
+      "historyDetail": "Detalye ng Kasaysayan",
+      "close": "Isara",
+      "fields": {
+        "completedAt": "Nakumpleto Noong",
+        "completedBy": "Kinumpleto Ng"
+      }
+    },
+    "csv": {
+      "date": "Petsa ng Konsultasyon",
+      "time": "Oras ng Konsultasyon",
+      "filename": "kasaysayan-ng-konsultasyon_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "Layunin ng Paggamit ng Personal na Impormasyon (APPI Art. 17)",
       "usagePurposeHint": "Ipinapakita sa patakaran sa privacy at form ng reserbacyon.",
       "retentionLegalNote": "Itakda ang panahon ng pagpapanatili sa saklaw na kinakailangan para makamit ang layunin ng paggamit. Ang data na lumampas sa panahon ng pagpapanatili ay ipapaalam sa mga admin para sa manu-manong pagtanggal.",
+      "retentionVisitHistoryNote": "※ Ang kasaysayan ng konsultasyon (mga rekord ng nakumpletong konsultasyon) ay hindi saklaw ng patakaran sa pagpapanatili ng data. Permanenteng pinapanatili bilang medikal na rekord anuman ang setting ng panahon ng pagpapanatili. Mangyaring ipaalam sa mga pasyente sa pamamagitan ng inyong patakaran sa privacy.",
       "reminderEmailTitle": "Reminder Email",
       "reminderEmailLabel": "Paganahin ang feature ng reminder email",
       "reminderEmailHint": "Kapag pinagana, ang form ng reserbacyon ay magpapakita ng checkbox ng pahintulot para sa mga reminder email. Ang mga reminder ay ipapadala lamang sa mga pasyenteng pumayag.",

--- a/oas-spa/src/i18n/locales/tl/toast.json
+++ b/oas-spa/src/i18n/locales/tl/toast.json
@@ -1,6 +1,6 @@
 {
   "cancelReasonRequired": "Pakiusap pumili ng dahilan ng pagkansela",
-  "cancelSuccess": "Nakansela ang reserbасyon (naipadala ang email na abiso sa pasyente)",
+  "cancelSuccess": "Nakansela ang reserbacyon (naipadala ang email na abiso sa pasyente)",
   "statusUpdated": "Na-update ang katayuan",
   "updateFailed": "Nabigo ang pag-update",
   "settingSaved": "Nai-save ang mga setting",
@@ -15,5 +15,7 @@
   "maxUsersReached": "Maximum na {{max}} user ang pinahihintulutan.",
   "emailPasswordRequired": "Pakiusap ilagay ang email at password",
   "invalidEmail": "Hindi valid ang format ng email address",
-  "passwordChanged": "Matagumpay na nabago ang password"
+  "passwordChanged": "Matagumpay na nabago ang password",
+  "visitCompleted": "Nairekord bilang nakumpleto ang konsultasyon",
+  "alreadyCompleted": "Ang reserbacyon na ito ay nakumpleto na"
 }

--- a/oas-spa/src/i18n/locales/vi/admin.json
+++ b/oas-spa/src/i18n/locales/vi/admin.json
@@ -6,7 +6,8 @@
     "logout": "Đăng Xuất",
     "lastLogin": "Đăng nhập lần cuối: ",
     "consentPending": "Chờ xác nhận điều khoản",
-    "proxyBooking": "Đặt hộ bệnh nhân"
+    "proxyBooking": "Đặt hộ bệnh nhân",
+    "visitHistory": "Lịch sử khám"
   },
   "dashboard": {
     "kpi": {
@@ -20,6 +21,7 @@
       "pending": "Chưa Xác Nhận",
       "confirmed": "Đã Xác Nhận",
       "cancelled": "Đã Hủy",
+      "completed": "Đã khám xong",
       "csvExport": "Xuất CSV",
       "clearFilters": "Xóa Bộ Lọc"
     },
@@ -40,14 +42,16 @@
       "symptoms": "Triệu Chứng",
       "phone": "Điện Thoại",
       "reservationDate": "Ngày Đặt Lịch",
-      "status": "Trạng Thái"
+      "status": "Trạng Thái",
+      "clearSort": "Xóa sắp xếp"
     },
     "status": {
       "pending": "Chưa Xác Nhận",
       "confirmed": "Đã Xác Nhận",
       "cancelled": "Đã Hủy",
       "cancelledByAdmin": "Quản Trị Viên",
-      "cancelledByPatient": "Bệnh Nhân"
+      "cancelledByPatient": "Bệnh Nhân",
+      "completed": "Đã khám xong"
     },
     "action": {
       "detail": "Chi Tiết"
@@ -57,6 +61,7 @@
       "reservationDetail": "Chi Tiết Đặt Lịch",
       "close": "Đóng",
       "markConfirmed": "Đánh Dấu Đã Xác Nhận",
+      "markCompleted": "Hoàn tất khám",
       "cancel": "Hủy",
       "fields": {
         "reservationId": "Mã Đặt Lịch",
@@ -81,7 +86,9 @@
         "cancelledBy": "Người Hủy",
         "cancelReason": "Lý Do Hủy",
         "cancelledAt": "Thời Gian Hủy",
-        "createdAt": "Ngày Đặt Lịch"
+        "createdAt": "Ngày Đặt Lịch",
+        "completedAt": "Thời gian hoàn tất",
+        "completedBy": "Người thao tác"
       },
       "symptomsTitle": "Triệu Chứng của {{name}}",
       "notesLabel": "Ghi Chú"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "Thay Đổi Trạng Thái",
       "statusChangeMessage": "Đánh dấu đặt lịch của {{name}} là đã xác nhận?",
-      "okLabel": "Đánh Dấu Đã Xác Nhận"
+      "okLabel": "Đánh Dấu Đã Xác Nhận",
+      "completeTitle": "Hoàn tất khám",
+      "completeMessage": "Đánh dấu cuộc khám của {{name}} là hoàn tất? Sẽ được lưu vào lịch sử khám.",
+      "completeOkLabel": "Hoàn tất"
     },
     "cancelModal": {
       "title": "Hủy Đặt Lịch",
@@ -112,6 +122,47 @@
       "date": "Ngày",
       "time": "Giờ",
       "filename": "dat-lich_"
+    }
+  },
+  "history": {
+    "title": "Lịch sử khám",
+    "search": {
+      "name": "Họ tên",
+      "namePlaceholder": "Yamada Taro",
+      "zip": "Mã bưu điện",
+      "zipPlaceholder": "123-4567",
+      "phone": "Điện thoại",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "Ngày khám Từ",
+      "visitDateTo": "Ngày khám Đến"
+    },
+    "filter": {
+      "clearFilters": "Xóa tìm kiếm",
+      "csvExport": "Xuất CSV"
+    },
+    "table": {
+      "visitDateTime": "Ngày giờ khám",
+      "name": "Họ tên",
+      "visitType": "Lần đầu/Tái khám",
+      "phone": "Điện thoại",
+      "clearSort": "Xóa sắp xếp"
+    },
+    "action": {
+      "detail": "Chi tiết"
+    },
+    "emptyState": "Không có lịch sử khám",
+    "modal": {
+      "historyDetail": "Chi tiết lịch sử khám",
+      "close": "Đóng",
+      "fields": {
+        "completedAt": "Thời gian hoàn tất",
+        "completedBy": "Người thao tác"
+      }
+    },
+    "csv": {
+      "date": "Ngày khám",
+      "time": "Giờ khám",
+      "filename": "lich-su-kham_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "Mục Đích Sử Dụng Thông Tin (APPI Điều 17)",
       "usagePurposeHint": "Hiển thị trong chính sách bảo mật và form đặt lịch.",
       "retentionLegalNote": "Hãy đặt thời gian lưu trữ trong phạm vi cần thiết để đạt được mục đích sử dụng. Dữ liệu quá hạn sẽ được thông báo cho quản trị viên để xóa thủ công.",
+      "retentionVisitHistoryNote": "※ Lịch sử khám (hồ sơ khám hoàn tất) không nằm trong chính sách lưu trữ dữ liệu. Được lưu trữ vĩnh viễn như hồ sơ y tế bất kể cài đặt thời hạn lưu trữ. Vui lòng thông báo cho bệnh nhân qua chính sách bảo mật.",
       "reminderEmailTitle": "Email Nhắc Nhở",
       "reminderEmailLabel": "Bật tính năng email nhắc nhở",
       "reminderEmailHint": "Khi bật, form đặt lịch sẽ hiển thị hộp kiểm đồng ý nhận email nhắc nhở. Email chỉ được gửi cho bệnh nhân đã đồng ý.",

--- a/oas-spa/src/i18n/locales/vi/toast.json
+++ b/oas-spa/src/i18n/locales/vi/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "Tối đa {{max}} người dùng.",
   "emailPasswordRequired": "Vui lòng nhập email và mật khẩu",
   "invalidEmail": "Định dạng địa chỉ email không hợp lệ",
-  "passwordChanged": "Đổi mật khẩu thành công"
+  "passwordChanged": "Đổi mật khẩu thành công",
+  "visitCompleted": "Đã đánh dấu hoàn tất khám",
+  "alreadyCompleted": "Cuộc hẹn này đã hoàn tất khám"
 }

--- a/oas-spa/src/i18n/locales/zh-CN/admin.json
+++ b/oas-spa/src/i18n/locales/zh-CN/admin.json
@@ -6,7 +6,8 @@
     "logout": "退出登录",
     "lastLogin": "最后登录: ",
     "consentPending": "待同意条款",
-    "proxyBooking": "代客预约"
+    "proxyBooking": "代客预约",
+    "visitHistory": "诊察记录"
   },
   "dashboard": {
     "kpi": {
@@ -21,7 +22,8 @@
       "confirmed": "已确认",
       "cancelled": "已取消",
       "csvExport": "导出CSV",
-      "clearFilters": "清除"
+      "clearFilters": "清除",
+      "completed": "诊察完成"
     },
     "search": {
       "name": "姓名",
@@ -40,14 +42,16 @@
       "symptoms": "症状",
       "phone": "电话",
       "reservationDate": "预约日期",
-      "status": "状态"
+      "status": "状态",
+      "clearSort": "清除排序"
     },
     "status": {
       "pending": "未确认",
       "confirmed": "已确认",
       "cancelled": "已取消",
       "cancelledByAdmin": "管理员",
-      "cancelledByPatient": "患者"
+      "cancelledByPatient": "患者",
+      "completed": "诊察完成"
     },
     "action": {
       "detail": "详情"
@@ -57,6 +61,7 @@
       "reservationDetail": "预约详情",
       "close": "关闭",
       "markConfirmed": "标为已确认",
+      "markCompleted": "诊察完成",
       "cancel": "取消",
       "fields": {
         "reservationId": "预约编号",
@@ -81,7 +86,9 @@
         "cancelledBy": "取消方",
         "cancelReason": "取消原因",
         "cancelledAt": "取消日时",
-        "createdAt": "预约日期"
+        "createdAt": "预约日期",
+        "completedAt": "诊察完成日时",
+        "completedBy": "完成操作者"
       },
       "symptomsTitle": "{{name}}的症状",
       "notesLabel": "备注"
@@ -89,7 +96,10 @@
     "confirmDialog": {
       "statusChange": "更改状态",
       "statusChangeMessage": "将{{name}}的预约标为已确认？",
-      "okLabel": "标为已确认"
+      "okLabel": "标为已确认",
+      "completeTitle": "诊察完成",
+      "completeMessage": "将{{name}}的诊察标为完成？将保存到诊察记录。",
+      "completeOkLabel": "标为完成"
     },
     "cancelModal": {
       "title": "取消预约",
@@ -112,6 +122,47 @@
       "date": "预约日",
       "time": "预约时间",
       "filename": "预约数据_"
+    }
+  },
+  "history": {
+    "title": "诊察记录",
+    "search": {
+      "name": "姓名",
+      "namePlaceholder": "山田太郎",
+      "zip": "邮政编码",
+      "zipPlaceholder": "123-4567",
+      "phone": "电话",
+      "phonePlaceholder": "090-1234-5678",
+      "visitDateFrom": "就诊日期 从",
+      "visitDateTo": "就诊日期 至"
+    },
+    "filter": {
+      "clearFilters": "清除搜索",
+      "csvExport": "导出CSV"
+    },
+    "table": {
+      "visitDateTime": "诊疗日时",
+      "name": "姓名",
+      "visitType": "初/复诊",
+      "phone": "电话",
+      "clearSort": "清除排序"
+    },
+    "action": {
+      "detail": "详情"
+    },
+    "emptyState": "暂无诊察记录",
+    "modal": {
+      "historyDetail": "诊察记录详情",
+      "close": "关闭",
+      "fields": {
+        "completedAt": "诊察完成日时",
+        "completedBy": "完成操作者"
+      }
+    },
+    "csv": {
+      "date": "诊察日",
+      "time": "诊察时间",
+      "filename": "诊察记录_"
     }
   },
   "settings": {
@@ -235,6 +286,7 @@
       "usagePurposeLabel": "个人信息利用目的（APPI第17条）",
       "usagePurposeHint": "显示在隐私政策和预约表单中。",
       "retentionLegalNote": "请根据个人信息保护法，在实现利用目的所必要的范围内设定保存期限。超过期限的数据将通知管理员，可手动删除。",
+      "retentionVisitHistoryNote": "※ 就诊记录（诊疗完成记录）不在数据保留期限范围内。作为医疗记录，无论保留期限设置如何，将永久保存。请通过隐私政策告知患者。",
       "reminderEmailTitle": "提醒邮件配送",
       "reminderEmailLabel": "启用提醒邮件功能",
       "reminderEmailHint": "启用后，预约表单将显示「接收提醒邮件」的同意复选框。仅向同意的患者发送就诊前一天的提醒邮件。",

--- a/oas-spa/src/i18n/locales/zh-CN/toast.json
+++ b/oas-spa/src/i18n/locales/zh-CN/toast.json
@@ -15,5 +15,7 @@
   "maxUsersReached": "最多允许{{max}}名用户。",
   "emailPasswordRequired": "请输入邮箱和密码",
   "invalidEmail": "邮箱地址格式不正确",
-  "passwordChanged": "密码修改成功"
+  "passwordChanged": "密码修改成功",
+  "visitCompleted": "已标记为诊察完成",
+  "alreadyCompleted": "此预约已诊察完成"
 }

--- a/oas-spa/src/pages/admin/Dashboard.tsx
+++ b/oas-spa/src/pages/admin/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useReservations, useKpis, updateReservationStatus, exportReservationsCsv } from '@/hooks/useAdmin';
+import { useReservations, useKpis, updateReservationStatus, exportReservationsCsv, completeVisit } from '@/hooks/useAdmin';
 import { useToast } from '@/hooks/useToast';
 import { Card, CardBody } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
@@ -21,6 +21,7 @@ const STATUS_BADGE_CLS: Record<ReservationStatus, string> = {
   pending:   'bg-amber-100 text-amber-700',
   confirmed: 'bg-emerald-100 text-emerald-700',
   cancelled: 'bg-red-100 text-red-700',
+  completed: 'bg-sky-100 text-sky-700',
 };
 
 const KPI_ICONS = [
@@ -82,6 +83,9 @@ export default function Dashboard() {
   const [updating, setUpdating] = useState(false);
   const [cancelReason, setCancelReason] = useState('');
   const [cancelReasonOther, setCancelReasonOther] = useState('');
+  // 診察完了確認
+  const [completeTarget, setCompleteTarget] = useState<ReservationRecord | null>(null);
+  const [completing, setCompleting] = useState(false);
 
   // ソート
   const [sortKeys, setSortKeys] = useState<SortKey[]>([{ col: 'datetime', dir: 'desc' }]);
@@ -219,6 +223,7 @@ export default function Dashboard() {
       pending:   t('dashboard.status.pending'),
       confirmed: t('dashboard.status.confirmed'),
       cancelled: t('dashboard.status.cancelled'),
+      completed: t('dashboard.status.completed'),
     },
     filename: `${t('dashboard.csv.filename')}${new Date().toISOString().slice(0, 10)}.csv`,
   };
@@ -263,7 +268,7 @@ export default function Dashboard() {
           {/* 1段目: ステータスタブ */}
           <div className="flex items-center justify-between">
             <div className="flex gap-1">
-              {(['all', 'pending', 'confirmed', 'cancelled'] as const).map(s => (
+              {(['all', 'pending', 'confirmed', 'completed', 'cancelled'] as const).map(s => (
                 <Button
                   key={s}
                   size="sm"
@@ -274,6 +279,11 @@ export default function Dashboard() {
                 </Button>
               ))}
             </div>
+            {sortKeys.length > 0 && !(sortKeys.length === 1 && sortKeys[0].col === 'datetime' && sortKeys[0].dir === 'desc') && (
+              <Button size="sm" variant="ghost" onClick={() => setSortKeys([{ col: 'datetime', dir: 'desc' }])}>
+                {t('dashboard.table.clearSort')}
+              </Button>
+            )}
             <Button size="sm" variant="secondary" onClick={() => exportReservationsCsv(sorted, csvLabels)}>
               <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -447,7 +457,7 @@ export default function Dashboard() {
             <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
               {t('dashboard.modal.close')}
             </Button>
-            {selected.status !== 'confirmed' && (
+            {selected.status !== 'completed' && selected.status !== 'confirmed' && (
               <Button size="sm" onClick={() => setConfirmAction({ booking: selected, status: 'confirmed' })}>
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -455,7 +465,15 @@ export default function Dashboard() {
                 {t('dashboard.modal.markConfirmed')}
               </Button>
             )}
-            {selected.status !== 'cancelled' && (
+            {selected.status === 'confirmed' && (
+              <Button size="sm" variant="secondary" onClick={() => setCompleteTarget(selected)}>
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {t('dashboard.modal.markCompleted')}
+              </Button>
+            )}
+            {selected.status !== 'completed' && selected.status !== 'cancelled' && (
               <Button size="sm" variant="danger" onClick={() => setConfirmAction({ booking: selected, status: 'cancelled' })}>
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -489,6 +507,36 @@ export default function Dashboard() {
         variant="primary"
         onConfirm={handleStatusUpdate}
         onCancel={() => setConfirmAction(null)}
+      />
+
+      {/* 診察完了確認ダイアログ */}
+      <ConfirmDialog
+        open={!!completeTarget}
+        title={t('dashboard.confirmDialog.completeTitle')}
+        message={t('dashboard.confirmDialog.completeMessage', { name: completeTarget?.name })}
+        okLabel={t('dashboard.confirmDialog.completeOkLabel')}
+        variant="primary"
+        loading={completing}
+        onConfirm={async () => {
+          if (!completeTarget) return;
+          setCompleting(true);
+          try {
+            await completeVisit(completeTarget.id);
+            showToast(tToast('visitCompleted'), 'success');
+            setSelected(null);
+          } catch (err: unknown) {
+            const error = err as { error?: string };
+            if (error?.error === 'ALREADY_COMPLETED') {
+              showToast(tToast('alreadyCompleted'), 'error');
+            } else {
+              showToast(tToast('updateFailed'), 'error');
+            }
+          } finally {
+            setCompleting(false);
+            setCompleteTarget(null);
+          }
+        }}
+        onCancel={() => setCompleteTarget(null)}
       />
 
       {/* キャンセル確認（理由必須） */}

--- a/oas-spa/src/pages/admin/Settings.tsx
+++ b/oas-spa/src/pages/admin/Settings.tsx
@@ -221,8 +221,8 @@ function BasicInfoTab({ form, update }: { form: Partial<ClinicSettings>; update:
                 style={{ border: 0 }}
                 loading="lazy"
                 referrerPolicy="no-referrer-when-downgrade"
-                src={`https://www.google.com/maps?q=${encodeURIComponent((form.clinicAddress || '') + ' ' + (form.clinicAddressSub || ''))}&output=embed&hl=ja`}
-                sandbox="allow-scripts allow-same-origin"
+                src={`https://www.google.com/maps?q=${encodeURIComponent((form.clinicAddress || '') + ' ' + (form.clinicAddressSub || ''))}&output=embed&hl=ja&z=16`}
+                sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
               />
             </div>
           </div>
@@ -790,7 +790,7 @@ function PolicyTab({ form, update }: { form: Partial<ClinicSettings>; update: (p
   /** テンプレートテキストを生成（日本語固定 — 日本法準拠の書式） */
   function generateTexts() {
     return {
-      privacyPolicy: `プライバシーポリシー\n\n${name}（以下「当院」）は、患者様の個人情報の保護に努め、個人情報の保護に関する法律（個人情報保護法）を遵守いたします。\n\n【収集する情報】\nお名前、ふりがな、生年月日、住所、電話番号、メールアドレス、症状・お悩み（要配慮個人情報）、保険証情報\n\n【利用目的】\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n【第三者提供】\nご本人の同意なく、個人情報を第三者に提供することはありません。ただし、法令に基づく場合を除きます。\n\n【要配慮個人情報の取り扱い】\n症状・お悩み等の健康に関する情報は「要配慮個人情報」として、ご本人の明示的な同意を得た上で取得・利用いたします。\n\n【データの保存期間】\nお預かりした個人情報は、利用目的の達成後、当院が定める保存期間を経て安全に削除いたします。\n\n【開示・訂正・利用停止】\nご自身の個人情報の開示・訂正・利用停止をご希望の場合は、下記の窓口までご連絡ください。本人確認の上、法令に基づき対応いたします。\n\n【お問い合わせ窓口】\n${name} 個人情報相談窓口\n電話: ${phone}`,
+      privacyPolicy: `プライバシーポリシー\n\n${name}（以下「当院」）は、患者様の個人情報の保護に努め、個人情報の保護に関する法律（個人情報保護法）を遵守いたします。\n\n【収集する情報】\nお名前、ふりがな、生年月日、住所、電話番号、メールアドレス、症状・お悩み（要配慮個人情報）、保険証情報\n\n【利用目的】\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n【第三者提供】\nご本人の同意なく、個人情報を第三者に提供することはありません。ただし、法令に基づく場合を除きます。\n\n【要配慮個人情報の取り扱い】\n症状・お悩み等の健康に関する情報は「要配慮個人情報」として、ご本人の明示的な同意を得た上で取得・利用いたします。\n\n【データの保存期間】\nお預かりした個人情報は、利用目的の達成後、当院が定める保存期間を経て安全に削除いたします。ただし、診察完了記録（診察履歴）は、医療記録の保全を目的として、保存期間設定に関わらず永久に保持されます。\n\n【開示・訂正・利用停止】\nご自身の個人情報の開示・訂正・利用停止をご希望の場合は、下記の窓口までご連絡ください。本人確認の上、法令に基づき対応いたします。\n\n【お問い合わせ窓口】\n${name} 個人情報相談窓口\n電話: ${phone}`,
       sensitiveDataConsentText: `「症状・お悩み」欄に入力される健康に関する情報は、個人情報保護法上の「要配慮個人情報」に該当する可能性があります。${name}の予約対応・施術準備の目的でのみ使用し、ご本人の同意なく第三者に提供することはありません。`,
       dataRetentionPurpose: `${name}は、ご予約時にご提供いただく個人情報を、以下の目的で利用いたします。\n\n1. 予約の受付・確認・変更・キャンセル処理\n2. 診療準備のための症状・お悩みの事前把握\n3. 予約確認・リマインダー等のご連絡\n4. 再来院時の前回情報参照\n5. サービス改善のための匿名化統計分析\n\n上記目的の達成後、所定の保存期間を経て安全に削除いたします。`,
       patientRightsContact: `個人情報の開示・訂正・利用停止をご希望の場合は、下記までご連絡ください。\n\n窓口: ${name} 個人情報相談窓口\n電話: ${phone}\n\n本人確認の上、法令に基づき対応いたします。`,
@@ -922,6 +922,9 @@ function PolicyTab({ form, update }: { form: Partial<ClinicSettings>; update: (p
           </p>
           <Alert variant="info">
             {t('settings.policy.retentionLegalNote')}
+          </Alert>
+          <Alert variant="warning">
+            {t('settings.policy.retentionVisitHistoryNote')}
           </Alert>
         </CardBody>
       </Card>

--- a/oas-spa/src/pages/admin/VisitHistory.tsx
+++ b/oas-spa/src/pages/admin/VisitHistory.tsx
@@ -1,0 +1,283 @@
+import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useVisitHistories, exportVisitHistoriesCsv } from '@/hooks/useAdmin';
+import { Card, CardBody } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Badge } from '@/components/ui/Badge';
+import { Modal } from '@/components/ui/Modal';
+import { Spinner } from '@/components/ui/Spinner';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { SortableHeader, toggleSortKey, multiSort, type SortKey } from '@/components/shared/SortableHeader';
+import { formatDateTimeJa, calcAge } from '@/utils/date';
+import type { VisitHistoryRecord } from '@/types/reservation';
+
+/** ソート用値取得 */
+function getValue(r: VisitHistoryRecord, col: string): string | number {
+  switch (col) {
+    case 'datetime':   return `${r.date} ${r.time}`;
+    case 'name':       return r.furigana || r.name;
+    case 'visitType':  return r.visitType || '';
+    case 'phone':      return r.phone;
+    default:           return '';
+  }
+}
+
+export default function VisitHistory() {
+  const { t } = useTranslation('admin');
+  const { histories, loading } = useVisitHistories();
+
+  // 検索
+  const [search, setSearch] = useState('');
+  const [zipSearch, setZipSearch] = useState('');
+  const [phoneSearch, setPhoneSearch] = useState('');
+  const [visitDateFrom, setVisitDateFrom] = useState('');
+  const [visitDateTo, setVisitDateTo] = useState('');
+
+  // ソート
+  const [sortKeys, setSortKeys] = useState<SortKey[]>([{ col: 'datetime', dir: 'desc' }]);
+  function handleSort(key: string) { setSortKeys(prev => toggleSortKey(prev, key)); }
+
+  // 詳細モーダル
+  const [selected, setSelected] = useState<VisitHistoryRecord | null>(null);
+
+  /** フィルター */
+  const filtered = useMemo(() => {
+    let list = histories;
+    if (search) {
+      const q = search.toLowerCase();
+      list = list.filter(r => r.name.toLowerCase().includes(q) || r.furigana.toLowerCase().includes(q));
+    }
+    if (zipSearch) {
+      const q = zipSearch.replace(/[-\s]/g, '');
+      list = list.filter(r => (r.zip || '').replace(/[-\s]/g, '').includes(q));
+    }
+    if (phoneSearch) {
+      const q = phoneSearch.replace(/[-\s]/g, '');
+      list = list.filter(r => r.phone.replace(/[-\s]/g, '').includes(q));
+    }
+    if (visitDateFrom) {
+      list = list.filter(r => r.date >= visitDateFrom);
+    }
+    if (visitDateTo) {
+      list = list.filter(r => r.date <= visitDateTo);
+    }
+    return list;
+  }, [histories, search, zipSearch, phoneSearch, visitDateFrom, visitDateTo]);
+
+  const sorted = useMemo(() => multiSort(filtered, sortKeys, getValue), [filtered, sortKeys]);
+
+  const hasFilter = search || zipSearch || phoneSearch || visitDateFrom || visitDateTo;
+
+  function clearFilters() {
+    setSearch('');
+    setZipSearch('');
+    setPhoneSearch('');
+    setVisitDateFrom('');
+    setVisitDateTo('');
+  }
+
+  /** CSV出力ラベル構築 */
+  const csvLabels = {
+    headers: [
+      t('dashboard.modal.fields.reservationId'),
+      t('history.csv.date'),
+      t('history.csv.time'),
+      t('dashboard.modal.fields.name'),
+      t('dashboard.modal.fields.furigana'),
+      t('dashboard.modal.fields.birthdate'),
+      t('dashboard.modal.fields.address'),
+      t('dashboard.modal.fields.phone'),
+      t('dashboard.modal.fields.email'),
+      t('dashboard.modal.fields.gender'),
+      t('dashboard.modal.fields.visitType'),
+      t('dashboard.modal.fields.insurance'),
+      t('dashboard.modal.fields.symptoms'),
+      t('dashboard.modal.fields.notes'),
+      t('dashboard.modal.fields.contactMethod'),
+      t('dashboard.modal.fields.reservationStatus'),
+      t('dashboard.modal.fields.createdAt'),
+      t('history.modal.fields.completedAt'),
+      t('history.modal.fields.completedBy'),
+    ],
+    statusLabels: {
+      pending:   t('dashboard.status.pending'),
+      confirmed: t('dashboard.status.confirmed'),
+      cancelled: t('dashboard.status.cancelled'),
+      completed: t('dashboard.status.completed'),
+    },
+    filename: `${t('history.csv.filename')}${new Date().toISOString().slice(0, 10)}.csv`,
+  };
+
+  if (loading) return <Spinner className="py-12" />;
+
+  return (
+    <div className="space-y-6 animate-fade-in-up">
+      {/* タイトル */}
+      <h1 className="text-xl font-heading font-semibold text-navy-700">{t('history.title')}</h1>
+
+      {/* 検索 + CSV */}
+      <Card>
+        <CardBody className="space-y-3">
+          <div className="flex items-center justify-between">
+            <div className="flex gap-2">
+              {hasFilter && (
+                <Button size="sm" variant="ghost" onClick={clearFilters}>
+                  {t('history.filter.clearFilters')}
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2">
+              {sortKeys.length > 0 && !(sortKeys.length === 1 && sortKeys[0].col === 'datetime' && sortKeys[0].dir === 'desc') && (
+                <Button size="sm" variant="ghost" onClick={() => setSortKeys([{ col: 'datetime', dir: 'desc' }])}>
+                  {t('history.table.clearSort')}
+                </Button>
+              )}
+              <Button size="sm" variant="secondary" onClick={() => exportVisitHistoriesCsv(sorted, csvLabels)}>
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                </svg>
+                {t('history.filter.csvExport')}
+              </Button>
+            </div>
+          </div>
+          <div className="grid grid-cols-5 gap-2">
+            <Input
+              label={t('history.search.name')}
+              placeholder={t('history.search.namePlaceholder')}
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+            />
+            <Input
+              label={t('history.search.zip')}
+              placeholder={t('history.search.zipPlaceholder')}
+              value={zipSearch}
+              onChange={e => setZipSearch(e.target.value)}
+            />
+            <Input
+              label={t('history.search.phone')}
+              placeholder={t('history.search.phonePlaceholder')}
+              value={phoneSearch}
+              onChange={e => setPhoneSearch(e.target.value)}
+            />
+            <Input
+              label={t('history.search.visitDateFrom')}
+              type="date"
+              value={visitDateFrom}
+              onChange={e => setVisitDateFrom(e.target.value)}
+            />
+            <Input
+              label={t('history.search.visitDateTo')}
+              type="date"
+              value={visitDateTo}
+              onChange={e => setVisitDateTo(e.target.value)}
+            />
+          </div>
+        </CardBody>
+      </Card>
+
+      {/* テーブル */}
+      <Card>
+        <div className="overflow-x-auto">
+          {sorted.length === 0 ? (
+            <EmptyState
+              icon={
+                <svg className="w-10 h-10" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+                </svg>
+              }
+              title={t('history.emptyState')}
+              className="py-8"
+            />
+          ) : (
+            <table className="w-full text-sm border-separate border-spacing-0">
+              <thead>
+                <tr className="border-b border-cream-200">
+                  <SortableHeader label={t('history.table.visitDateTime')} sortKey="datetime" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label={t('history.table.name')} sortKey="name" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label={t('history.table.visitType')} sortKey="visitType" sortKeys={sortKeys} onSort={handleSort} />
+                  <SortableHeader label={t('history.table.phone')} sortKey="phone" sortKeys={sortKeys} onSort={handleSort} />
+                  <th className="px-3 py-3 text-[11px] font-medium text-navy-400 whitespace-nowrap tracking-wider uppercase text-left bg-cream-100/50 last:rounded-tr-lg" />
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map(r => (
+                  <tr key={r.id} className="border-b border-cream-100 hover:bg-cream-100/60 transition-colors">
+                    <td className="px-3 py-3 whitespace-nowrap font-mono text-navy-700 text-xs">
+                      {formatDateTimeJa(r.date, r.time)}
+                    </td>
+                    <td className="px-3 py-3 whitespace-nowrap">
+                      <div className="text-navy-700 font-medium">{r.name}</div>
+                      <div className="text-[11px] text-navy-400">{r.furigana}</div>
+                    </td>
+                    <td className="px-3 py-3 whitespace-nowrap">
+                      <Badge className={r.visitType === '初診' ? 'bg-sky-100 text-sky-700' : 'bg-cream-100 text-navy-500'}>
+                        {r.visitType || '-'}
+                      </Badge>
+                    </td>
+                    <td className="px-3 py-3 whitespace-nowrap text-navy-500 font-mono text-xs">{r.phone}</td>
+                    <td className="px-3 py-3 whitespace-nowrap">
+                      <Button size="sm" variant="ghost" onClick={() => setSelected(r)}>
+                        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        </svg>
+                        {t('history.action.detail')}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </Card>
+
+      {/* 詳細モーダル（閲覧のみ） */}
+      {selected && (
+        <Modal open={!!selected} onClose={() => setSelected(null)} title={t('history.modal.historyDetail')} className="max-w-lg">
+          <div className="overflow-y-auto -mx-5 px-5" style={{ maxHeight: 'calc(85vh - 10rem)' }}>
+            <dl className="space-y-1 text-sm">
+              {[
+                [t('dashboard.modal.fields.reservationId'), selected.reservationId],
+                [t('dashboard.modal.fields.scheduledDateTime'), formatDateTimeJa(selected.date, selected.time)],
+                [t('dashboard.modal.fields.name'), selected.name],
+                [t('dashboard.modal.fields.furigana'), selected.furigana],
+                [t('dashboard.modal.fields.birthdate'), selected.birthdate + (calcAge(selected.birthdate) !== null ? `（${calcAge(selected.birthdate)}${t('dashboard.modal.fields.ageUnit')}）` : '')],
+                [t('dashboard.modal.fields.zip'), selected.zip || '-'],
+                [t('dashboard.modal.fields.address'), selected.address],
+                [t('dashboard.modal.fields.phone'), selected.phone],
+                [t('dashboard.modal.fields.email'), selected.email || '-'],
+                [t('dashboard.modal.fields.gender'), selected.gender || t('dashboard.modal.fields.genderUnset')],
+                [t('dashboard.modal.fields.visitType'), selected.visitType || '-'],
+                [t('dashboard.modal.fields.insurance'), selected.insurance || '-'],
+                [t('dashboard.modal.fields.symptoms'), selected.symptoms],
+                [t('dashboard.modal.fields.notes'), selected.notes || t('dashboard.modal.fields.noNotes')],
+                [t('dashboard.modal.fields.contactMethod'), selected.contactMethod || '-'],
+                [t('dashboard.modal.fields.reservationStatus'), t(`dashboard.status.${selected.reservationStatus}`)],
+                ...(selected.cancelledBy ? [
+                  [t('dashboard.modal.fields.cancelledBy'), selected.cancelledBy === 'admin' ? t('dashboard.status.cancelledByAdmin') : t('dashboard.status.cancelledByPatient')],
+                  [t('dashboard.modal.fields.cancelReason'), selected.cancelReason || '-'],
+                  [t('dashboard.modal.fields.cancelledAt'), selected.cancelledAt ? new Date(selected.cancelledAt).toLocaleString('ja-JP') : '-'],
+                ] : []),
+                [t('dashboard.modal.fields.createdAt'), selected.reservationCreatedAt ? new Date(selected.reservationCreatedAt).toLocaleString('ja-JP') : '-'],
+                [t('history.modal.fields.completedAt'), selected.completedAt ? new Date(selected.completedAt).toLocaleString('ja-JP') : '-'],
+                [t('history.modal.fields.completedBy'), selected.completedByEmail || '-'],
+              ].map(([label, val]) => (
+                <div key={label} className="flex border-b border-cream-200/80 py-2">
+                  <dt className="w-24 shrink-0 text-navy-400">{label}</dt>
+                  <dd className="text-navy-700 whitespace-pre-wrap break-all">{val}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+          <div className="flex gap-2 justify-end pt-4 border-t border-cream-200/60 mt-4">
+            <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
+              {t('history.modal.close')}
+            </Button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/oas-spa/src/types/reservation.ts
+++ b/oas-spa/src/types/reservation.ts
@@ -1,5 +1,5 @@
 /** 予約ステータス */
-export type ReservationStatus = 'pending' | 'confirmed' | 'cancelled';
+export type ReservationStatus = 'pending' | 'confirmed' | 'cancelled' | 'completed';
 
 /** 初診・再診区分 */
 export type VisitType = '初診' | '再診';
@@ -68,6 +68,42 @@ export interface ReservationFormData {
   hasSensitiveDataConsent: boolean;
   /** [H2] リマインダーメール配信同意 */
   reminderEmailConsent: boolean;
+}
+
+/** 診察履歴レコード（visit_histories コレクション） */
+export interface VisitHistoryRecord {
+  id: string;
+  reservationId: string;
+  /** 患者情報スナップショット */
+  date: string;
+  time: string;
+  name: string;
+  furigana: string;
+  birthdate: string;
+  zip: string;
+  address: string;
+  phone: string;
+  email: string;
+  gender: Gender;
+  visitType: VisitType;
+  insurance: InsuranceType;
+  symptoms: string;
+  notes: string;
+  contactMethod: ContactMethod;
+  hasSensitiveDataConsent: boolean;
+  reminderEmailConsent: boolean;
+  /** 予約メタデータ */
+  reservationCreatedAt: string;
+  reservationStatus: string;
+  /** キャンセル情報（キャンセル後に完了にした場合） */
+  cancelledBy?: 'admin' | 'patient';
+  cancelReason?: string;
+  cancelledAt?: string;
+  /** 診察完了メタデータ */
+  completedAt: string;
+  completedBy: string;
+  completedByEmail: string;
+  createdAt: string;
 }
 
 /** 時間スロット（slots コレクション） */


### PR DESCRIPTION
## Summary
- **completeVisit Cloud Function**: トランザクションベース、二重完了防止（409）、admin認証必須
- **visit_histories Firestoreコレクション**: 不変設計（update/delete禁止）、保存期間ポリシー対象外で永久保持
- **/admin/history画面**: 氏名・郵便番号・電話・日付範囲検索、マルチソート、CSV出力、詳細モーダル（閲覧のみ）
- **Dashboard**: confirmed予約に「診察完了」ボタン追加、completedステータスバッジ
- **APPI対応**: Settings保存期間セクションに診察履歴永久保持の警告注記、PPプレースホルダーに永久保持明記
- **Google Maps embed**: sandbox属性にallow-popups追加（「マップで開く」修正）
- **i18n**: 7言語（ja/en/ko/zh-CN/vi/pt-BR/tl）全対応

## Test plan
- [ ] エミュレーターで管理者ログイン → Dashboard → confirmed予約で「診察完了」ボタン押下
- [ ] 二重完了時に409エラートースト表示確認
- [ ] /admin/history画面で検索・ソート・CSV出力・詳細モーダル確認
- [ ] Settings → ポリシータブ → 保存期間セクションに警告バナー表示確認
- [ ] Firestoreルール: visit_histories update/delete拒否確認
- [ ] 各言語切替でi18n表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)