### PR TITLE
[AUDIT-02] 予約フォームに診察履歴保管通知を追加

### DIFF
--- a/oas-spa/src/i18n/locales/en/booking.json
+++ b/oas-spa/src/i18n/locales/en/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "Email address is required when contact method is \"Email\"",
     "validationEmailFormat": "Invalid email address format",
     "validationSensitiveConsent": "Please consent to the handling of your health information",
-    "validationSymptomsRequired": "Please enter your symptoms / concerns"
+    "validationSymptomsRequired": "Please enter your symptoms / concerns",
+    "visitHistoryNotice": "The information you enter will be retained as part of your visit history. Please refer to our Privacy Policy for details on the retention period and how your data is handled."
   },
   "confirm": {
     "appointmentDateTime": "Appointment Date & Time",

--- a/oas-spa/src/i18n/locales/ja/booking.json
+++ b/oas-spa/src/i18n/locales/ja/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "連絡方法が「メール」の場合、メールアドレスは必須です",
     "validationEmailFormat": "メールアドレスの形式が正しくありません",
     "validationSensitiveConsent": "健康情報の取り扱いに同意してください",
-    "validationSymptomsRequired": "症状・お悩みを入力してください"
+    "validationSymptomsRequired": "症状・お悩みを入力してください",
+    "visitHistoryNotice": "ご入力いただいた情報は、診察履歴として保管されます。保管期間および取り扱いについては、プライバシーポリシーをご確認ください。"
   },
   "confirm": {
     "appointmentDateTime": "ご予約日時",

--- a/oas-spa/src/i18n/locales/ko/booking.json
+++ b/oas-spa/src/i18n/locales/ko/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "연락 방법이 \"이메일\"인 경우 이메일 주소는 필수입니다",
     "validationEmailFormat": "이메일 주소 형식이 올바르지 않습니다",
     "validationSensitiveConsent": "건강 정보 취급에 동의해 주세요",
-    "validationSymptomsRequired": "증상・고민을 입력해 주세요"
+    "validationSymptomsRequired": "증상・고민을 입력해 주세요",
+    "visitHistoryNotice": "입력하신 정보는 진찰 이력으로 보관됩니다. 보관 기간 및 취급 방법에 대해서는 개인정보 처리방침을 확인해 주세요."
   },
   "confirm": {
     "appointmentDateTime": "예약 일시",

--- a/oas-spa/src/i18n/locales/pt-BR/booking.json
+++ b/oas-spa/src/i18n/locales/pt-BR/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "O e-mail é obrigatório quando o método de contato é \"E-mail\"",
     "validationEmailFormat": "Formato de e-mail inválido",
     "validationSensitiveConsent": "Por favor, consinta com o tratamento das suas informações de saúde",
-    "validationSymptomsRequired": "Por favor, informe seus sintomas / queixas"
+    "validationSymptomsRequired": "Por favor, informe seus sintomas / queixas",
+    "visitHistoryNotice": "As informações inseridas serão armazenadas como parte do seu histórico de consultas. Consulte nossa Política de Privacidade para obter detalhes sobre o período de retenção e como seus dados são tratados."
   },
   "confirm": {
     "appointmentDateTime": "Data e Hora da Consulta",

--- a/oas-spa/src/i18n/locales/tl/booking.json
+++ b/oas-spa/src/i18n/locales/tl/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "Kinakailangan ang email kapag ang paraan ng pakikipag-ugnayan ay \"Email\"",
     "validationEmailFormat": "Hindi tamang format ng email address",
     "validationSensitiveConsent": "Mangyaring sumang-ayon sa paghawak ng iyong impormasyon sa kalusugan",
-    "validationSymptomsRequired": "Mangyaring ilagay ang iyong mga sintomas / alalahanin"
+    "validationSymptomsRequired": "Mangyaring ilagay ang iyong mga sintomas / alalahanin",
+    "visitHistoryNotice": "Ang impormasyong inilagay mo ay itatago bilang bahagi ng iyong kasaysayan ng pagbisita. Pakitingnan ang aming Patakaran sa Privacy para sa mga detalye tungkol sa panahon ng pagpapanatili at kung paano pinamamahalaan ang iyong data."
   },
   "confirm": {
     "appointmentDateTime": "Petsa at Oras ng Appointment",

--- a/oas-spa/src/i18n/locales/vi/booking.json
+++ b/oas-spa/src/i18n/locales/vi/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "Địa chỉ email là bắt buộc khi phương thức liên hệ là \"Email\"",
     "validationEmailFormat": "Địa chỉ email không đúng định dạng",
     "validationSensitiveConsent": "Vui lòng đồng ý với việc xử lý thông tin sức khỏe",
-    "validationSymptomsRequired": "Vui lòng nhập triệu chứng/vấn đề"
+    "validationSymptomsRequired": "Vui lòng nhập triệu chứng/vấn đề",
+    "visitHistoryNotice": "Thông tin bạn nhập sẽ được lưu trữ như một phần của lịch sử khám bệnh. Vui lòng tham khảo Chính sách Bảo mật để biết chi tiết về thời gian lưu trữ và cách xử lý dữ liệu."
   },
   "confirm": {
     "appointmentDateTime": "Ngày & Giờ hẹn",

--- a/oas-spa/src/i18n/locales/zh-CN/booking.json
+++ b/oas-spa/src/i18n/locales/zh-CN/booking.json
@@ -85,7 +85,8 @@
     "validationEmailRequiredForMail": "联系方式为\"邮件\"时，电子邮件为必填项",
     "validationEmailFormat": "电子邮件格式不正确",
     "validationSensitiveConsent": "请同意健康信息的处理方式",
-    "validationSymptomsRequired": "请输入症状/烦恼"
+    "validationSymptomsRequired": "请输入症状/烦恼",
+    "visitHistoryNotice": "您输入的信息将作为诊察记录保存。有关保存期限和处理方式，请参阅隐私政策。"
   },
   "confirm": {
     "appointmentDateTime": "预约日期及时间",

--- a/oas-spa/src/pages/booking/PatientForm.tsx
+++ b/oas-spa/src/pages/booking/PatientForm.tsx
@@ -266,6 +266,13 @@ export function PatientForm({ form, onUpdate, onNext, onBack, privacyPolicyUrl }
             </p>
           )}
         </div>
+        {/* [AUDIT-02] 診察履歴保管通知（APPI 第32条 — 利用目的の通知義務） */}
+        <div className="flex items-start gap-2 rounded-lg border border-sky-200 bg-sky-50/60 px-3.5 py-3">
+          <svg className="w-4 h-4 shrink-0 mt-0.5 text-sky-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <p className="text-xs text-sky-700 leading-relaxed">{t('patientForm.visitHistoryNotice')}</p>
+        </div>
         <Textarea label={t('patientForm.symptoms')} value={form.symptoms} onChange={e => onUpdate({ symptoms: e.target.value })} rows={3} placeholder={t('patientForm.symptomsPlaceholder')} required disabled={!form.hasSensitiveDataConsent} maxLength={1000} />
         <Textarea label={t('patientForm.notes')} value={form.notes} onChange={e => onUpdate({ notes: e.target.value })} rows={2} placeholder={t('patientForm.notesPlaceholder')} maxLength={500} />
       </div>


### PR DESCRIPTION
## 概要

APPI（個人情報保護法）第32条の利用目的通知義務に対応。予約フォームの要配慮個人情報同意ブロック直後に、診察履歴として情報が保管される旨の通知バナーを追加。

## 変更内容

- **PatientForm.tsx**: `sensitiveDataConsent` ブロック直後に `visitHistoryNotice` バナー追加（青系インフォバナー + 情報アイコン）
- **7言語 i18n 対応**: ja / en / ko / zh-CN / pt-BR / vi / tl の `booking.json` に `patientForm.visitHistoryNotice` キーを追加

## 配置理由

健康情報への同意直後に「その情報が診察履歴として保管される」ことを示すことで、APPI第32条の利用目的通知が自然な流れで機能する。

## 法的根拠

個人情報保護法 第32条（保有個人データに関する事項の公表等）— 利用目的の明示義務

## テスト観点

- [ ] 全7言語で正しい文言が表示されること
- [ ] sensitiveDataConsent ブロック直後に表示されること
- [ ] 既存の同意フロー・バリデーションに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)